### PR TITLE
SQL code to copy QA'd [stage] files to the [final] schema

### DIFF
--- a/claims_db/phclaims/final/tables/load_final.mcaid_mcare_elig_demo.sql
+++ b/claims_db/phclaims/final/tables/load_final.mcaid_mcare_elig_demo.sql
@@ -1,0 +1,28 @@
+/****** COPY FROM STAGE to FINAL  ******/
+	IF OBJECT_ID('[PHClaims].[final].[mcaid_mcare_elig_demo]', 'U') IS NOT NULL 
+		DROP TABLE [PHClaims].[final].[mcaid_mcare_elig_demo]
+
+	SELECT *
+		INTO [PHClaims].[final].[mcaid_mcare_elig_demo]	
+		FROM [PHClaims].[stage].[mcaid_mcare_elig_demo]
+
+
+/****** ADD COLUMSTORE CLUSTERED INDEX ******/
+	CREATE CLUSTERED COLUMNSTORE INDEX idx_final_mcaid_mcare_elig_demo
+	ON [PHClaims].[final].[mcaid_mcare_elig_demo]
+	WITH (DROP_EXISTING = OFF)
+
+
+/****** BASIC ERROR CHECKING COMPARING STAGE & FINAL ******/
+	SELECT COUNT(*) FROM [PHClaims].[stage].[mcaid_mcare_elig_demo]
+	SELECT COUNT(*) FROM [PHClaims].[final].[mcaid_mcare_elig_demo]
+
+	SELECT geo_kc, 
+	count(*) FROM [PHClaims].[stage].[mcaid_mcare_elig_demo]
+	  GROUP BY geo_kc
+	  ORDER BY -count(*)
+
+	 SELECT geo_kc, 
+	count(*) FROM [PHClaims].[final].[mcaid_mcare_elig_demo]
+	  GROUP BY geo_kc
+	  ORDER BY -count(*)

--- a/claims_db/phclaims/final/tables/load_final.mcaid_mcare_elig_timevar.sql
+++ b/claims_db/phclaims/final/tables/load_final.mcaid_mcare_elig_timevar.sql
@@ -1,0 +1,28 @@
+/****** COPY FROM STAGE to FINAL  ******/
+	IF OBJECT_ID('[PHClaims].[final].[mcaid_mcare_elig_timevar]', 'U') IS NOT NULL 
+		DROP TABLE [PHClaims].[final].[mcaid_mcare_elig_timevar]
+
+	SELECT *
+		INTO [PHClaims].[final].[mcaid_mcare_elig_timevar]	
+		FROM [PHClaims].[stage].[mcaid_mcare_elig_timevar]
+
+
+/****** ADD COLUMSTORE CLUSTERED INDEX ******/
+	CREATE CLUSTERED COLUMNSTORE INDEX idx_final_mcaid_mcare_elig_timevar
+	ON [PHClaims].[final].[mcaid_mcare_elig_timevar]
+	WITH (DROP_EXISTING = OFF)
+
+
+/****** BASIC ERROR CHECKING COMPARING STAGE & FINAL ******/
+	SELECT COUNT(*) FROM [PHClaims].[stage].[mcaid_mcare_elig_timevar]
+	SELECT COUNT(*) FROM [PHClaims].[final].[mcaid_mcare_elig_timevar]
+
+	SELECT contiguous, 
+	count(*) FROM [PHClaims].[stage].[mcaid_mcare_elig_timevar]
+	  GROUP BY contiguous
+	  ORDER BY -count(*)
+
+	 SELECT contiguous, 
+	count(*) FROM [PHClaims].[final].[mcaid_mcare_elig_timevar]
+	  GROUP BY contiguous
+	  ORDER BY -count(*)

--- a/claims_db/phclaims/final/tables/load_final.mcare_elig_demo.sql
+++ b/claims_db/phclaims/final/tables/load_final.mcare_elig_demo.sql
@@ -1,0 +1,28 @@
+/****** COPY FROM STAGE to FINAL  ******/
+	IF OBJECT_ID('[PHClaims].[final].[mcare_elig_demo]', 'U') IS NOT NULL 
+		DROP TABLE [PHClaims].[final].[mcare_elig_demo]
+
+	SELECT *
+		INTO [PHClaims].[final].[mcare_elig_demo]	
+		FROM [PHClaims].[stage].[mcare_elig_demo]
+
+
+/****** ADD COLUMSTORE CLUSTERED INDEX ******/
+	CREATE CLUSTERED COLUMNSTORE INDEX idx_final_mcare_elig_demo
+	ON [PHClaims].[final].[mcare_elig_demo]
+	WITH (DROP_EXISTING = OFF)
+
+
+/****** BASIC ERROR CHECKING COMPARING STAGE & FINAL ******/
+	SELECT COUNT(*) FROM [PHClaims].[stage].[mcare_elig_demo]
+	SELECT COUNT(*) FROM [PHClaims].[final].[mcare_elig_demo]
+
+	SELECT geo_kc, 
+	count(*) FROM [PHClaims].[stage].[mcare_elig_demo]
+	  GROUP BY geo_kc
+	  ORDER BY -count(*)
+
+	 SELECT geo_kc, 
+	count(*) FROM [PHClaims].[final].[mcare_elig_demo]
+	  GROUP BY geo_kc
+	  ORDER BY -count(*)

--- a/claims_db/phclaims/final/tables/load_final.mcare_elig_timevar.sql
+++ b/claims_db/phclaims/final/tables/load_final.mcare_elig_timevar.sql
@@ -1,0 +1,28 @@
+/****** COPY FROM STAGE to FINAL  ******/
+	IF OBJECT_ID('[PHClaims].[final].[mcare_elig_timevar]', 'U') IS NOT NULL 
+		DROP TABLE [PHClaims].[final].[mcare_elig_timevar]
+
+	SELECT *
+		INTO [PHClaims].[final].[mcare_elig_timevar]	
+		FROM [PHClaims].[stage].[mcare_elig_timevar]
+
+
+/****** ADD COLUMSTORE CLUSTERED INDEX ******/
+	CREATE CLUSTERED COLUMNSTORE INDEX idx_final_mcare_elig_timevar
+	ON [PHClaims].[final].[mcare_elig_timevar]
+	WITH (DROP_EXISTING = OFF)
+
+
+/****** BASIC ERROR CHECKING COMPARING STAGE & FINAL ******/
+	SELECT COUNT(*) FROM [PHClaims].[stage].[mcare_elig_timevar]
+	SELECT COUNT(*) FROM [PHClaims].[final].[mcare_elig_timevar]
+
+	SELECT contiguous, 
+	count(*) FROM [PHClaims].[stage].[mcare_elig_timevar]
+	  GROUP BY contiguous
+	  ORDER BY -count(*)
+
+	 SELECT contiguous, 
+	count(*) FROM [PHClaims].[final].[mcare_elig_timevar]
+	  GROUP BY contiguous
+	  ORDER BY -count(*)

--- a/claims_db/phclaims/final/tables/load_final.xwalk_apde_mcaid_mcare_pha.sql
+++ b/claims_db/phclaims/final/tables/load_final.xwalk_apde_mcaid_mcare_pha.sql
@@ -1,0 +1,21 @@
+/****** COPY FROM STAGE to FINAL  ******/
+	IF OBJECT_ID('[PHClaims].[final].[xwalk_apde_mcaid_mcare_pha]', 'U') IS NOT NULL 
+		DROP TABLE [PHClaims].[final].[xwalk_apde_mcaid_mcare_pha]
+
+	SELECT *
+		INTO [PHClaims].[final].[xwalk_apde_mcaid_mcare_pha]	
+		FROM [PHClaims].[stage].[xwalk_apde_mcaid_mcare_pha]
+
+
+/****** ADD COLUMSTORE CLUSTERED INDEX ******/
+	CREATE CLUSTERED COLUMNSTORE INDEX idx_final_xwalk_apde_mcaid_mcare_pha
+	ON [PHClaims].[final].[xwalk_apde_mcaid_mcare_pha]
+	WITH (DROP_EXISTING = OFF)
+
+
+/****** BASIC ERROR CHECKING COMPARING STAGE & FINAL ******/
+	SELECT COUNT(*) FROM [PHClaims].[stage].[xwalk_apde_mcaid_mcare_pha]
+	SELECT COUNT(*) FROM [PHClaims].[final].[xwalk_apde_mcaid_mcare_pha]
+
+	SELECT SUM(CAST(id_apde AS BIGINT)) FROM [PHClaims].[stage].[xwalk_apde_mcaid_mcare_pha]
+	SELECT SUM(CAST(id_apde AS BIGINT)) FROM [PHClaims].[final].[xwalk_apde_mcaid_mcare_pha]


### PR DESCRIPTION
Creates the following SQL tables (with Clustered Columnstore indices):
- [PHClaims].[final].[mcare_elig_timevar]
- [PHClaims].[final].[mcare_elig_demo]
- [PHClaims].[final].[mcaid_mcare_elig_timevar]
- [PHClaims].[final].[mcaid_mcare_elig_demo]
- [PHClaims].[final].[xwalk_apde_mcaid_mcare_pha]