### PR TITLE
Modifications to 3 general ETL scripts to accommodate APCD data

### DIFF
--- a/claims_db/db_loader/scripts_general/create_table.R
+++ b/claims_db/db_loader/scripts_general/create_table.R
@@ -153,18 +153,19 @@ create_table_f <- function(
     # Use unique in case variables are repeated
     years <- sort(unique(table_config$years))
     
-    # Set up new table name
-    to_table <- paste0(to_table, "_", x)
-    
-    # Add additional year-specific variables if present
-    if ("vars" %in% names(table_config[[x]])) {
-      vars <- c(table_config$vars, table_config[[add_vars_name]][[vars]])
-    }
-    
-    
     message(glue::glue("Creating calendar year [{to_schema}].[{to_table}] tables", test_msg))
     
     lapply(years, function(x) {
+      
+      # Set up new table name
+      to_table <- paste0(to_table, "_", x)
+      
+      # Add additional year-specific variables if present
+      if ("vars" %in% names(table_config[[x]])) {
+        vars <- c(table_config$vars, table_config[[add_vars_name]][[vars]])
+      }
+      else vars <- table_config$vars
+      
       if (overwrite == T) {
         if (DBI::dbExistsTable(conn, DBI::Id(schema = to_schema, table = to_table))) {
           DBI::dbExecute(conn, 

--- a/claims_db/db_loader/scripts_general/etl_log.R
+++ b/claims_db/db_loader/scripts_general/etl_log.R
@@ -109,7 +109,7 @@ load_metadata_etl_log_f <- function(conn = NULL,
   
   
   #### CHECK ABOUT CREATING NEW ENTRY ####
-  if ((auto_proceed == T )& nrow(matches == 0) | nrow(latest_source) == 0) {
+  if ((auto_proceed == T )& nrow(matches) == 0 | nrow(latest_source) == 0) {
     proceed <- T
     } 
   

--- a/claims_db/db_loader/scripts_general/load_table.R
+++ b/claims_db/db_loader/scripts_general/load_table.R
@@ -36,7 +36,7 @@ load_table_from_file_f <- function(
   
   #### SET UP SERVER ####
   if (is.null(server)) {
-    server <- NA
+    server <- NULL
   } else if (server %in% c("phclaims", "hhsaw")) {
     server <- server
   } else if (!server %in% c("phclaims", "hhsaw")) {


### PR DESCRIPTION
Hi Alastair,

I've made changes to three of the general ETL scripts used to load claims data, in order to accommodate the APCD data. I think the changes were necessary as a result of enhancements you and Jeremy implemented to allow the functions to work on both PHClaims and the HHSAW.

create_table_f -> had to bring table part name code within the lapply loop, and add a line to accommodate the scenario where there are no individual year table variables.

load_table_from_file_f -> had to change the server to NULL rather than NA for code to work

load_metadata_etl_f -> a parentheses in the code checking for the auto_proceed parameter was in the wrong place