### PR TITLE
Improved load of IDs to temp table, avoids skipping some IDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: claims
-Version: 0.1.9
+Version: 0.1.10
 Title: Query and analyze WA State Medicaid, Medicare, and APCD data
 Description: LARGELY FOR INTERNAL USE
   This package is for querying and analyzing WA State Medicaid, Medicare, and 

--- a/R/elig_timevar_collapse.R
+++ b/R/elig_timevar_collapse.R
@@ -214,53 +214,21 @@ elig_timevar_collapse <- function(conn,
       message("Large number of IDs detected, setting up IDs in temp table")
       temp_ids <- T
       
-      # Can only write 1000 values at a time so may need to do multiple rounds
-      n_rounds <- ceiling(num_ids/1000)
-      list_start <- 1
-      list_end <- min(1000, num_ids)
-      i <- 1
-      
-      # Make progress bar
-      print(glue::glue("Loading {n_rounds} ID sets"))
-      pb <- txtProgressBar(min = 0, max = n_rounds, style = 3)
-      
-      for (i in 1:n_rounds) {
-        if (i == 1) {
-          # Clear temp table with standalone command
-          # (otherwise switching between just ID and individual dates causes an error)
-          DBI::dbExecute(conn, "IF object_id('tempdb..##temp_ids') IS NOT NULL DROP TABLE ##temp_ids;")
-          id_load <- glue::glue_sql("CREATE TABLE ##temp_ids (id VARCHAR(20));
-                                    INSERT INTO ##temp_ids (id) VALUES 
-                                    ('
-                                    {DBI::SQL(glue::glue_collapse(ids[list_start:list_end], sep = \"'), ('\"))}
-                                    ');",
-                                    .con = conn)
-          DBI::dbExecute(conn, id_load)
-        } else {
-          id_load <- glue::glue_sql("INSERT INTO ##temp_ids (id) VALUES 
-                                    ('
-                                    {DBI::SQL(glue::glue_collapse(ids[list_start:list_end], sep = \"'), ('\"))}
-                                    ');",
-                                    .con = conn)
-          DBI::dbExecute(conn, id_load)
-        }
-        
-        list_start <- list_start + 1000
-        list_end <- min(list_end + 1000, num_ids)
-        
-        # Update progress bar
-        setTxtProgressBar(pb, i)
-      }
+      try(dbExecute(db_hhsaw, "drop table ##temp_ids"), silent = T)
+      DBI::dbWriteTable(db_hhsaw,
+                        name = "##temp_ids",
+                        value = data.frame("id" = ids),
+                        overwrite = T, append = F)
       
       # Add index to id and from_date for faster join
       # Think about only using this if n_rounds is >2-3
       DBI::dbExecute(conn, "CREATE NONCLUSTERED INDEX temp_ids_id ON ##temp_ids (id)")
       
-      
       id_sql <- glue::glue_sql(") a 
                                 INNER JOIN ##temp_ids x
                                 ON a.{`id_name`} = x.id ",
                                .con = conn)
+      message("Temp IDs table created")
     } else {
       temp_ids <- F
       id_sql <- glue::glue_sql(" WHERE {`id_name`} IN ({ids*}) ) a", .con = conn)


### PR DESCRIPTION
The elig_timevar_collapse function had been skipping some IDs when loading to the temp table. Instead of inserting each ID though code, now using dbWriteTable to load in a single go. Extremely large numbers of IDs may encounter network issues when loading to the SQL DB, but this is yet to be shown. Added a QA check to flag discrepancies.