### PR TITLE
Remove centroid vars

### DIFF
--- a/R/elig_timevar_collapse.R
+++ b/R/elig_timevar_collapse.R
@@ -36,20 +36,22 @@
 #' @param geo_city Collapse over the geo_city field (Medicaid only).
 #' @param geo_state Collapse over the geo_state field (Medicaid only).
 #' @param geo_zip Collapse over the geo_zip field (Medicaid only).
-#' @param geocode_vars Bring in all geocded data elements (geo_zip_centroid, 
-#' geo_street_centroid, geo_county_code, geo_tractce10, geo_hra_code, 
-#' geo_school_code). Default is FALSE.
+#' @param geocode_vars Bring in all geocded data elements (geo_county_code,
+#' geo_tractce10, geo_hra_code, geo_school_code). Default is FALSE.
 #' @param geo_zip_code Collapse over the geo_zip_code field (APCD only).
 #' @param geo_county Collapse over the geo_countyfield (APCD only).
 #' @param geo_ach Collapse over the geo_ach field (APCD only).
 #'
 #' @examples
 #' \dontrun{
-#' new_timevar <- elig_timevar_collapse(conn = db_claims51, source = "mcaid",
-#' full_benefit = T, geo_add1 = T, geo_city = T, geo_zip = T, geocode_vars = T)
-#' new_timevar2 <- elig_timevar_collapse(conn = db_claims51, source = "apcd",
-#' ids = c("123", "456", "789"), med_covgrp = T, geo_county = T)
-#' }
+#' new_timevar <- elig_timevar_collapse(conn = db_claims51, server="phclaims",
+#' source = "mcaid", full_benefit = T, geo_add1 = T, geo_city = T, geo_zip = T,
+#' geocode_vars = T)
+#' new_timevar2 <- elig_timevar_collapse(conn = db_claims51, server="phclaims",
+#' source = "apcd", med_covgrp = T, geo_county = T)
+#' new_timevar_hhsaw <- elig_timevar_collapse(conn = db_hhsaw, server="hhsaw",
+#' source = "mcaid", full_benefit = T, geo_add1 = T, geo_city = T, geo_zip = T,
+#' geocode_vars = T)
 #' 
 #' @export
 
@@ -175,9 +177,7 @@ elig_timevar_collapse <- function(conn,
   
   # Add in other variables as desired
   if (source == "mcaid" & geocode_vars == T) {
-    vars_geo <- c("geo_zip_centroid", 
-                  "geo_street_centroid", 
-                  "geo_county_code", 
+    vars_geo <- c("geo_county_code", 
                   "geo_tract_code",
                   "geo_hra_code", 
                   "geo_school_code")


### PR DESCRIPTION
Removes centroid variables since they are no longer present

Also updates examples to use server arguments