### PR TITLE
Removing procedure code number and consolidating modifier codes to single column

### DIFF
--- a/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_naloxone.R
+++ b/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_naloxone.R
@@ -6,6 +6,8 @@
 #
 # R script developed by Jeremy Whitehurst using SQL scripts from Eli Kern, Jennifer Liu and Spencer Hensley
 #
+# Update 2025-04-03 (Eli Kern): Tweak code given new modifier_code structure 
+#
 ## 
 
 ## Function elements
@@ -148,10 +150,7 @@ FROM {`final_schema`}.{`paste0(final_table, 'mcaid_claim_procedure')`} AS A
 WHERE year(last_service_date) >= 2016 
 	and 
 	(a.procedure_code in ('G1028', 'G2215', 'G2216 ', 'J2310', 'J2311') 
-		or 
-	a.procedure_code = 'J3490' and (modifier_1 in ('HG', 'TG') 
-	    or modifier_2 in ('HG', 'TG')
-		or modifier_3 in ('HG', 'TG') or modifier_4 in ('HG', 'TG')));",
+		or (a.procedure_code = 'J3490' and modifier_code in ('HG', 'TG')));",
 	  .con = conn)
   DBI::dbExecute(conn = conn, step2_sql)
   

--- a/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_procedure.R
+++ b/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_procedure.R
@@ -8,6 +8,8 @@
 # R functions created by: Alastair Matheson, PHSKC (APDE), 2019-05 and 2019-12
 # Modified by: Philip Sylling, 2019-06-11
 # 
+# Update 2025-04-03 (Eli Kern): Remove procedure_code_number column and consolidate modifier codes into a single column
+#
 # Data Pull Run time: 9.66 min
 # Create Index Run Time: 5.75 min
 # 
@@ -58,11 +60,7 @@ load_stage_mcaid_claim_procedure_f <- function(conn = NULL,
                                ,first_service_date
                                ,last_service_date
                                ,procedure_code
-                               ,cast(procedure_code_number as varchar(4)) as procedure_code_number
-                               ,modifier_1
-                               ,modifier_2
-                               ,modifier_3
-                               ,modifier_4
+                               ,modifier_code
                                ,getdate() as last_run
                                INTO {`to_schema`}.{`to_table`}
                                FROM 
@@ -93,7 +91,10 @@ load_stage_mcaid_claim_procedure_f <- function(conn = NULL,
                                ) as a
                                
                                unpivot(procedure_code for procedure_code_number in 
-                                       ([01],[02],[03],[04],[05],[06],[07],[08],[09],[10],[11],[12],[line])) as procedure_code;", 
+                                       ([01],[02],[03],[04],[05],[06],[07],[08],[09],[10],[11],[12],[line])) as procedure_code
+                               
+                               unpivot(modifier_code for modifier_code_number in 
+                                       ([modifier_1],[modifier_2],[modifier_3],[modifier_4])) as modifier_code;", 
                                .con = conn)
   
   message("Running step 2: Load to ", to_schema, ".", to_table)

--- a/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_procedure.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_procedure.yaml
@@ -30,9 +30,5 @@ vars:
     first_service_date: DATE
     last_service_date: DATE
     procedure_code: VARCHAR(200)
-    procedure_code_number: VARCHAR(4)
-    modifier_1: VARCHAR(200)
-    modifier_2: VARCHAR(200)
-    modifier_3: VARCHAR(200)
-    modifier_4: VARCHAR(200)
+    modifier_code: VARCHAR(200)
     last_run: DATETIME


### PR DESCRIPTION
The healthcare data team has learned that storing modifier codes in four separate columns is creating some duplication in the claim_procedure table. Additionally, the procedure_code_number column is not needed for analysis (as different classification systems of procedure codes [CPT, HCPCS, BETOS, ICD-PCS] can also be distinguished by length and/or composition), and this was also leading to some duplication of rows (for ICD-PCS codes). This coding revision removes the procedure_code_number column AND consolidates the four modifier code columns into a single column: modifier_code.