### PR TITLE
Revise claim_bh ETL script to include updated OUD definition developed by Jennifer Liu for OD2A: LOCAL work

### DIFF
--- a/claims_db/db_loader/scripts_general/claim_bh.R
+++ b/claims_db/db_loader/scripts_general/claim_bh.R
@@ -98,6 +98,8 @@ load_bh <- function(conn = NULL,
     claim_header_from_table <- table_config[[server]][["claim_header_from_table"]][[1]]
     claim_pharm_from_schema <- table_config[[server]][["claim_pharm_from_schema"]][[1]]
     claim_pharm_from_table <- table_config[[server]][["claim_pharm_from_table"]][[1]]
+    claim_procedure_from_schema <- table_config[[server]][["claim_procedure_from_schema"]][[1]]
+    claim_procedure_from_table <- table_config[[server]][["claim_procedure_from_table"]][[1]]
     icdcm_from_schema <- table_config[[server]][["icdcm_from_schema"]][[1]]
     icdcm_from_table <- table_config[[server]][["icdcm_from_table"]][[1]]
     ref_schema <- table_config[[server]][["ref_schema"]][[1]]
@@ -111,6 +113,8 @@ load_bh <- function(conn = NULL,
     claim_header_from_table <- table_config[["claim_header_from_table"]][[1]]
     claim_pharm_from_schema <- table_config[["claim_pharm_from_schema"]][[1]]
     claim_pharm_from_table <- table_config[["claim_pharm_from_table"]][[1]]
+    claim_procedure_from_schema <- table_config[["claim_procedure_from_schema"]][[1]]
+    claim_procedure_from_table <- table_config[["claim_procedure_from_table"]][[1]]
     icdcm_from_schema <- table_config[["icdcm_from_schema"]][[1]]
     icdcm_from_table <- table_config[["icdcm_from_table"]][[1]]
     # Assumes working in PHClaims for ref data if using older YAML format

--- a/claims_db/db_loader/scripts_general/claim_bh.R
+++ b/claims_db/db_loader/scripts_general/claim_bh.R
@@ -9,6 +9,7 @@
 ## Eli 6/13/24 update: Add branching logic for Rx fill date based on data source
 ## Eli 11/6/24 update: Simplify and revise logic such that from_date (now first_encounter_date) is earliest condition-defining encounter
   ## and to_date (now last_encounter_date) is last condition-defining encounter, removing need for rolling time window
+## Eli 6/3/25 update: Revise code to create Opioid Use Disorder flag using definition developed through OD2A: LOCAL grant
   
 ### Function elements
 # conn = database connection
@@ -132,6 +133,7 @@ load_bh <- function(conn = NULL,
   DBI::dbCreateTable(conn, tbl_name, fields = table_config$vars)
 
   #### STEP 3: CREATE TEMP TABLE TO HOLD CONDITION-SPECIFIC CLAIMS AND DATES ####
+  #Excluding Opioid Use Disorder (OUD), which is flagged using condition-specific logic
   #conn <- create_db_connection(server, interactive = interactive_auth, prod = prod)
   message("STEP 1: CREATE TEMP TABLE TO HOLD CONDITION-SPECIFIC CLAIMS AND DATES")
   time_start <- Sys.time()
@@ -153,7 +155,7 @@ load_bh <- function(conn = NULL,
                 ) as a
         INNER JOIN (SELECT sub_group_condition, code_set, code, icdcm_version, value_set_name
     		            FROM  {`ref_schema`}.{`ref_table`}
-    		            WHERE code_set in ('ICD9CM', 'ICD10CM') 
+    		            WHERE code_set in ('ICD9CM', 'ICD10CM') and sub_group_condition not in ('sud_opioid')
     		            ) as b
     		ON (a.icdcm_norm = b.code) and (a.icdcm_version = b.icdcm_version) 
    ) diag
@@ -171,7 +173,7 @@ load_bh <- function(conn = NULL,
     FROM {`claim_pharm_from_schema`}.{`claim_pharm_from_table`} a
     INNER JOIN (SELECT sub_group_condition, code_set, code
     	          FROM {`ref_schema`}.{`ref_table`}
-    	          WHERE code_set in ('NDC')) as b
+    	          WHERE code_set in ('NDC') and sub_group_condition not in ('sud_opioid')) as b
     ON a.ndc = b.code
           ) rx
       ",.con = conn)
@@ -199,23 +201,171 @@ load_bh <- function(conn = NULL,
     try(DBI::dbRemoveTable(conn, tbl_name <- DBI::Id(schema = schema, table = "tmp_collapse_bh")), silent = T)
     DBI::dbGetQuery(conn = conn, sql2)
     
-    #### STEP 5: INSERT ALL CONDITION TABLES INTO FINAL STAGE TABLE #### 
-    #conn <- create_db_connection(server, interactive = interactive_auth, prod = prod)
-    message("STEP 3: INSERT ALL CONDITION TABLES INTO FINAL STAGE TABLE")
+    #### STEP 5: CREATE TEMP TABLE TO HOLD PERSON-MONTHS WITH OUD DIAGNOSES #### 
+    
+    message("STEP 3: CREATE TEMP TABLE TO HOLD PERSON-MONTHS WITH OUD DIAGNOSES")
     # Build SQL query
-    sql3 <- glue_sql(
+    sql3 <- glue_sql("
+    --Identify all OUD-relevant claims using diagnosis, drug and procedure codes
+    with oud_claims as (
+    	SELECT  
+    	coalesce(diag.{`id_source`}, rx.{`id_source`}, pcode.{`id_source`}) as {`id_source`}
+    	,coalesce(diag.claim_header_id, rx.claim_header_id, pcode.claim_header_id) as claim_header_id
+    	,coalesce(diag.svc_date, rx.svc_date, pcode.svc_date) as svc_date
+    	,diag.icdcm_flag
+    	,rx.rx_flag
+    	,pcode.pcode_flag
+    	--BASED ON DIAGNOSIS
+    	FROM (
+    		SELECT DISTINCT
+    		{`id_source`}
+    		,claim_header_id
+    		,svc_date
+    		,1 as icdcm_flag
+    		FROM  (
+    			SELECT DISTINCT {`id_source`}, claim_header_id, icdcm_norm, icdcm_version, first_service_date as 'svc_date'
+    			FROM {`icdcm_from_schema`}.{`icdcm_from_table`}
+    		) as a
+    		INNER JOIN (
+    			SELECT sub_group_condition, code_set, code, icdcm_version, value_set_name
+    		FROM  {`ref_schema`}.{`ref_table`}
+    		WHERE code_set in ('ICD9CM', 'ICD10CM') and sub_group_condition = 'sud_opioid'
+    		) as b
+    		ON (a.icdcm_norm = b.code) and (a.icdcm_version = b.icdcm_version) 
+    	) as diag
+       
+    	FULL JOIN (
+    
+    		SELECT DISTINCT  
+    		{`id_source`}
+    		,claim_header_id
+    		,svc_date
+    		,1 as rx_flag
+    		-- BASED ON PRESCRIPTIONS
+    		FROM (
+    			SELECT DISTINCT
+    			a.{`id_source`}, a.claim_header_id, a.{`rx_fill_date`} as 'svc_date'
+    			FROM {`claim_pharm_from_schema`}.{`claim_pharm_from_table`} as a
+    			INNER JOIN (
+    				SELECT sub_group_condition, code_set, code
+    				FROM {`ref_schema`}.{`ref_table`}
+    				WHERE code_set in ('NDC') and sub_group_condition = 'sud_opioid'
+    			) as b
+    			ON a.ndc = b.code
+    		) as c
+    	) as rx
+    	on diag.claim_header_id = rx.claim_header_id
+    
+    	FULL JOIN (
+    
+    		SELECT DISTINCT
+    		{`id_source`}
+    		,claim_header_id
+    		,svc_date
+    		,1 as pcode_flag
+    		--BASED ON PROCEDURE CODES
+    		FROM (
+    			SELECT DISTINCT a.{`id_source`}
+    			,a.claim_header_id
+    			,a.first_service_date as 'svc_date'
+    			FROM {`claim_procedure_from_schema`}.{`claim_procedure_from_table`} as a
+    			INNER JOIN (
+    				SELECT sub_group_condition, code_set, code
+    				FROM {`ref_schema`}.{`ref_table`}
+    				WHERE value_set_name in ('apde-moud-procedure') and sub_group_condition = 'sud_opioid'
+    			) as b
+    			ON a.procedure_code = b.code
+    		) as c
+    	) as pcode
+    	on diag.claim_header_id = pcode.claim_header_id
+    ),
+    
+    --Identify all person-months where people have an OUD diagnosis
+    oud_diag_month as (
+    	select distinct a.{`id_source`},
+    	b.first_day_month as first_encounter_date,
+    	b.last_day_month as last_encounter_date
+    	from oud_claims as a
+    	inner join {`schema`}.ref_date as b
+    	on a.svc_date = b.[date]
+    	where a.icdcm_flag = 1
+    ),
+    
+    --Identify earliest OUD diagnosis month for each person
+    oud_diag_month_min as (
+    	select {`id_source`},
+    	min(first_encounter_date) as oud_diag_min
+    	from oud_diag_month
+    	group by {`id_source`}
+    ),
+    
+    --For MOUD headers not associated with an OUD diagnosis on the claim, flag those where an OUD diagnosis occurred anytime before the claim
+    moud_oud_ever as (
+    	select distinct
+    	a.*,
+    	case when b.oud_diag_min <= a.svc_date then 1 else 0 end as moud_include
+    	from (
+    		select *
+    		from oud_claims
+    		where icdcm_flag is null
+    	) as a
+    	inner join (
+    		select *
+    		from oud_diag_month_min
+    	) as b
+    	on a.{`id_source`} = b.{`id_source`}
+    ),
+    
+    --Identify all months with MOUD ever claims
+    moud_oud_ever_month as (
+    	select distinct {`id_source`},
+    	b.first_day_month as first_encounter_date,
+    	b.last_day_month as last_encounter_date
+    	from moud_oud_ever as a
+    	inner join {`schema`}.ref_date as b
+    	on a.svc_date = b.[date]
+    	where moud_include = 1
+    )
+    
+    --Union both sets of OUD-relevant person-months
+    select *, 'sud_opioid' as bh_cond
+    into {`schema`}.tmp_header_oud
+    from oud_diag_month
+    union select *, 'sud_opioid' as bh_cond
+    from moud_oud_ever_month;
+
+      ",.con = conn)
+    
+    #Run SQL query
+    try(DBI::dbRemoveTable(conn, tbl_name <- DBI::Id(schema = schema, table = "tmp_header_oud")), silent = T)
+    DBI::dbGetQuery(conn = conn, sql3)
+    
+    
+    #### STEP 6: INSERT ALL CONDITION TABLES INTO FINAL STAGE TABLE #### 
+    #conn <- create_db_connection(server, interactive = interactive_auth, prod = prod)
+    message("STEP 4: INSERT ALL CONDITIONS INTO FINAL STAGE TABLE")
+    # Build SQL query
+    sql4 <- glue_sql(
       "INSERT INTO {`schema`}.{`to_table`}
       SELECT
       {`id_source`}, first_encounter_date, last_encounter_date, bh_cond, 
       getdate() as last_run
-      FROM {`schema`}.tmp_collapse_bh;",
+      FROM {`schema`}.tmp_collapse_bh
+      
+      UNION
+      
+      SELECT
+      {`id_source`}, first_encounter_date, last_encounter_date, bh_cond, 
+      getdate() as last_run
+      FROM {`schema`}.tmp_header_oud;",
       .con = conn)
     
     #Run SQL query
-    dbGetQuery(conn = conn, sql3)  
+    dbGetQuery(conn = conn, sql4)  
     
     try(dbRemoveTable(conn, tbl_name <- DBI::Id(schema = schema, table = "tmp_header_bh")), silent = T)
     try(dbRemoveTable(conn, tbl_name <- DBI::Id(schema = schema, table = "tmp_collapse_bh")), silent = T)
+    try(dbRemoveTable(conn, tbl_name <- DBI::Id(schema = schema, table = "tmp_header_oud")), silent = T)
   
   #Run time of all steps
     time_end <- Sys.time()

--- a/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_bh.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_bh.yaml
@@ -13,7 +13,7 @@ hhsaw:
   final_table: final_mcaid_claim_bh
   final_table_pre: final_
   ref_schema: stg_reference
-  ref_table: rda_value_sets_apde
+  ref_table: ref_rda_value_sets_apde
   rolling_schema: stg_claims
   rolling_table: ref_rolling_time_24mo_2012_2020
   qa_schema: claims

--- a/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_bh.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_bh.yaml
@@ -3,10 +3,12 @@ hhsaw:
   claim_header_from_table: stage_mcaid_claim_header
   claim_pharm_from_schema: stg_claims
   claim_pharm_from_table: stage_mcaid_claim_pharm
+  claim_procedure_from_schema: stg_claims
+  claim_procedure_from_table: stage_mcaid_claim_procedure
   icdcm_from_schema: stg_claims
   icdcm_from_table: stage_mcaid_claim_icdcm_header
   to_schema: stg_claims
-  to_table: stage_mcaid_claim_bh
+  to_table: stage_mcaid_claim_bh_dev
   final_schema: claims
   final_table: final_mcaid_claim_bh
   final_table_pre: final_

--- a/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_bh.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcaid_claim_bh.yaml
@@ -8,7 +8,7 @@ hhsaw:
   icdcm_from_schema: stg_claims
   icdcm_from_table: stage_mcaid_claim_icdcm_header
   to_schema: stg_claims
-  to_table: stage_mcaid_claim_bh_dev
+  to_table: stage_mcaid_claim_bh
   final_schema: claims
   final_table: final_mcaid_claim_bh
   final_table_pre: final_

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_bh.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_bh.yaml
@@ -9,7 +9,7 @@ inthealth:
     icdcm_from_table: final_mcare_claim_icdcm_header
     to_schema: stg_claims
     to_table: stage_mcare_claim_bh_dev
-    ref_schema: stg_claims
+    ref_schema: stg_reference
     ref_table: ref_rda_value_sets_apde
     icdcm_ref_schema: stg_claims
     icdcm_ref_table: ref_icdcm_codes

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_bh.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_bh.yaml
@@ -3,10 +3,12 @@ inthealth:
     claim_header_from_table: final_mcare_claim_header
     claim_pharm_from_schema: stg_claims
     claim_pharm_from_table: final_mcare_claim_pharm
+    claim_procedure_from_schema: stg_claims
+    claim_procedure_from_table: final_mcare_claim_procedure
     icdcm_from_schema: stg_claims
     icdcm_from_table: final_mcare_claim_icdcm_header
     to_schema: stg_claims
-    to_table: stage_mcare_claim_bh
+    to_table: stage_mcare_claim_bh_dev
     ref_schema: stg_claims
     ref_table: ref_rda_value_sets_apde
     icdcm_ref_schema: stg_claims

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_bh.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_bh.yaml
@@ -8,7 +8,7 @@ inthealth:
     icdcm_from_schema: stg_claims
     icdcm_from_table: final_mcare_claim_icdcm_header
     to_schema: stg_claims
-    to_table: stage_mcare_claim_bh_dev
+    to_table: stage_mcare_claim_bh
     ref_schema: stg_reference
     ref_table: ref_rda_value_sets_apde
     icdcm_ref_schema: stg_claims


### PR DESCRIPTION
Unlike all other MH and SUD conditions in the claim_bh table, the "sud_opioid" definition now follows a time-bound approach that also makes use of procedure codes. Because of this, the from_date and to_date values for "sud_opioid" rows will be the beginning and ending of months, respectively, and thus the claim_bh table can be used to identify any month in which a person can be considered to have OUD.

This is different than the other BH conditions, for which the from_date and to_date contain the minimum and maximum service dates for which the BH condition was found.