### PR TITLE
To align with current Medicaid structure, remove procedure_code_number and consolidate modifier codes into single column

### DIFF
--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_naloxone.R
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_naloxone.R
@@ -3,6 +3,7 @@
 #
 # 2024-06
 #
+# Update 2025-07-18 (Eli Kern): Tweak code given new modifier_code structure 
 
 ### Run from 02_master_mcare_claims_analytic.R script
 # https://github.com/PHSKC-APDE/claims_data/blob/main/claims_db/db_loader/mcare/02_master_mcare_claims_analytic.R
@@ -192,10 +193,7 @@ load_stage.mcare_claim_naloxone_f <- function() {
     WHERE year(last_service_date) >= 2016 
     	and 
     	(a.procedure_code in ('G1028', 'G2215', 'G2216 ', 'J2310', 'J2311') 
-    		or 
-    	a.procedure_code = 'J3490' and (modifier_1 in ('HG', 'TG') 
-    	    or modifier_2 in ('HG', 'TG')
-    		or modifier_3 in ('HG', 'TG') or modifier_4 in ('HG', 'TG')));",
+    		or (a.procedure_code = 'J3490' and modifier_code in ('HG', 'TG')));",
             .con = inthealth))
         }
 

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.R
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.R
@@ -1242,8 +1242,8 @@ load_stage.mcare_claim_procedure_f <- function() {
     -------------------------
     --Step 11: Exclude claims among people with no enrollment data and insert into table shell
     -------------------------
+    insert into stg_claims.stage_mcare_claim_procedure_dev
     select a.*
-    into stg_claims.stage_mcare_claim_procedure_dev --test code
     from final_union as a
     left join (select distinct bene_id from stg_claims.mcare_bene_enrollment) as b
     on a.id_mcare = b.bene_id

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.R
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.R
@@ -4,6 +4,7 @@
 # 2019-12
 #
 #2024-05-15 Eli update: Data from HCA, ETL in inthealth_edw
+#2024-07-18 Eli update: Remove procedure code number and consolidate modifier codes into single column
 
 ### Run from 02_master_mcare_claims_analytic.R script
 # https://github.com/PHSKC-APDE/claims_data/blob/main/claims_db/db_loader/mcare/02_master_mcare_claims_analytic.R
@@ -13,158 +14,374 @@ load_stage.mcare_claim_procedure_f <- function() {
   
   ### Run SQL query
   odbc::dbGetQuery(inthealth, glue::glue_sql(
-    "--Code to load data to stage.mcare_claim_procedure table
-    --Procedure codes reshaped to long
-    --Eli Kern (PHSKC-APDE)
-    --2024-05
-        
-    ------------------
-    --STEP 1: Select and union desired columns from multi-year claim tables on stage schema
-    --Exclude all denied claims using proposed approach per ResDAC 01-2020 consult
-    --Unpivot and insert into table shell
-    -------------------
-    insert into stg_claims.stage_mcare_claim_procedure
-        
-    select distinct
-    z.id_mcare,
-    claim_header_id,
-    first_service_date,
-    last_service_date,
-    procedure_code,
-    procedure_code_number,
-    modifier_1,
-    modifier_2,
-    modifier_3,
-    modifier_4,
-    filetype_mcare,
-    getdate() as last_run
-        
-    from (
-        --bcarrier
-        select
-        id_mcare,
-        claim_header_id,
-        first_service_date,
-        last_service_date,
-        procedure_codes as 'procedure_code',
-        cast(substring(procedure_code_number, 3,10) as varchar(200)) as 'procedure_code_number',
-        case when (procedure_code_hcps_modifier_1 is null or procedure_code_hcps_modifier_1 = ' ') then null else procedure_code_hcps_modifier_1 end as modifier_1,
-        case when (procedure_code_hcps_modifier_2 is null or procedure_code_hcps_modifier_2 = ' ') then null else procedure_code_hcps_modifier_2 end as modifier_2,
-        case when (procedure_code_hcps_modifier_3 is null or procedure_code_hcps_modifier_3 = ' ') then null else procedure_code_hcps_modifier_3 end as modifier_3,
-        case when (procedure_code_hcps_modifier_4 is null or procedure_code_hcps_modifier_4 = ' ') then null else procedure_code_hcps_modifier_4 end as modifier_4,
-        filetype_mcare,
-        getdate() as last_run
-        
-        from (
-        	select
-        	--top 100
-      		trim(a.bene_id) as id_mcare,
-      		trim(a.clm_id) as claim_header_id,
-      		cast(a.clm_from_dt as date) as first_service_date,
-      		cast(a.clm_thru_dt as date) as last_service_date,
-        	'carrier' as filetype_mcare,
-        	b.hcpcs_cd as pchcpcs,
-        	b.hcpcs_1st_mdfr_cd as procedure_code_hcps_modifier_1,
-        	b.hcpcs_2nd_mdfr_cd as procedure_code_hcps_modifier_2,
-        	procedure_code_hcps_modifier_3 = null,
-        	procedure_code_hcps_modifier_4 = null,
-        	b.betos_cd as pcbetos
-        	from stg_claims.mcare_bcarrier_claims as a
-        	left join stg_claims.mcare_bcarrier_line as b
-        	on a.clm_id = b.clm_id
-        	--exclude denined claims using carrier/dme claim method
-        	where a.carr_clm_pmt_dnl_cd in ('1','2','3','4','5','6','7','8','9')
-        ) as x1
-        
-        --reshape from wide to long
-        unpivot(procedure_codes for procedure_code_number in (
-        	pchcpcs,
-        	pcbetos)
-        ) as procedure_codes
-        where procedure_codes is not null AND procedure_codes!=' ' 
-        	   
-        --dme
-        union
-        select
-        id_mcare,
-        claim_header_id,
-        first_service_date,
-        last_service_date,
-        procedure_codes as 'procedure_code',
-        cast(substring(procedure_code_number, 3,10) as varchar(200)) as 'procedure_code_number',
-        case when (procedure_code_hcps_modifier_1 is null or procedure_code_hcps_modifier_1 = ' ') then null else procedure_code_hcps_modifier_1 end as modifier_1,
-        case when (procedure_code_hcps_modifier_2 is null or procedure_code_hcps_modifier_2 = ' ') then null else procedure_code_hcps_modifier_2 end as modifier_2,
-        case when (procedure_code_hcps_modifier_3 is null or procedure_code_hcps_modifier_3 = ' ') then null else procedure_code_hcps_modifier_3 end as modifier_3,
-        case when (procedure_code_hcps_modifier_4 is null or procedure_code_hcps_modifier_4 = ' ') then null else procedure_code_hcps_modifier_4 end as modifier_4,
-        filetype_mcare,
-        getdate() as last_run
-        
-        from (
-        	select
-        	--top 100
-      		trim(a.bene_id) as id_mcare,
-      		trim(a.clm_id) as claim_header_id,
-      		cast(a.clm_from_dt as date) as first_service_date,
-      		cast(a.clm_thru_dt as date) as last_service_date,
-        	'dme' as filetype_mcare,
-        	b.hcpcs_cd as pchcpcs,
-        	b.hcpcs_1st_mdfr_cd as procedure_code_hcps_modifier_1,
-        	b.hcpcs_2nd_mdfr_cd as procedure_code_hcps_modifier_2,
-        	b.hcpcs_3rd_mdfr_cd as procedure_code_hcps_modifier_3,
-        	b.hcpcs_4th_mdfr_cd as procedure_code_hcps_modifier_4,
-        	b.betos_cd as pcbetos
-        	from stg_claims.mcare_dme_claims as a
-        	left join stg_claims.mcare_dme_line as b
-        	on a.clm_id = b.clm_id
-        	--exclude denined claims using carrier/dme claim method
-        	where a.carr_clm_pmt_dnl_cd in ('1','2','3','4','5','6','7','8','9')
-        ) as x2
-        
-        --reshape from wide to long
-        unpivot(procedure_codes for procedure_code_number in (
-        	pchcpcs,
-        	pcbetos)
-        ) as procedure_codes
-        where procedure_codes is not null AND procedure_codes!=' ' 
-        
-        --hha
-        --only one procedure code field thus no unpivot necessary
-        union
+    "----------------------
+    --Only HCPCS codes have modifier codes - ICD-PCS and BETOS codes do not
+    --The number of HCPCS modifier code columns depends upon claim type and ResDAC vintage
+    ----------------------
+    
+    -------------------------
+    --Step 1: BCARRIER claims
+    --Yes: HCPCS codes with 2 modifier code fields
+    --Yes: BETOS codes
+    --No: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    with bcarrier_base_data as (
         select
         --top 100
-      	trim(a.bene_id) as id_mcare,
-      	trim(a.clm_id) as claim_header_id,
-      	cast(a.clm_from_dt as date) as first_service_date,
-      	cast(a.clm_thru_dt as date) as last_service_date,
-        b.hcpcs_cd as procedure_code,
-        'hcpcs' as procedure_code_number,
-        case when (b.hcpcs_1st_mdfr_cd is null or b.hcpcs_1st_mdfr_cd = ' ') then null else b.hcpcs_1st_mdfr_cd end as modifier_1,
-        case when (b.hcpcs_2nd_mdfr_cd is null or b.hcpcs_2nd_mdfr_cd = ' ') then null else b.hcpcs_2nd_mdfr_cd end as modifier_2,
-        case when (b.hcpcs_3rd_mdfr_cd is null or b.hcpcs_3rd_mdfr_cd = ' ') then null else b.hcpcs_3rd_mdfr_cd end as modifier_3,
-        modifier_4 = null,
-        'hha' as filetype_mcare,
-        getdate() as last_run
-        from stg_claims.mcare_hha_base_claims as a
-        left join stg_claims.mcare_hha_revenue_center as b
+        trim(a.bene_id) as id_mcare,
+        trim(a.clm_id) as claim_header_id,
+        cast(a.clm_from_dt as date) as first_service_date,
+        cast(a.clm_thru_dt as date) as last_service_date,
+        'carrier' as filetype_mcare,
+        b.hcpcs_cd as pchcpcs,
+        b.hcpcs_1st_mdfr_cd as modifier_1,
+        b.hcpcs_2nd_mdfr_cd as modifier_2,
+        b.betos_cd as pcbetos
+        from stg_claims.mcare_bcarrier_claims as a
+        left join stg_claims.mcare_bcarrier_line as b
         on a.clm_id = b.clm_id
-        --exclude denined claims using facility claim method
-        where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
-        
-        --hospice
-        --only one procedure code field thus no unpivot necessary
-        union
+        --exclude denined claims using carrier/dme claim method
+        where a.carr_clm_pmt_dnl_cd in ('1','2','3','4','5','6','7','8','9')
+    ),
+    --HCPCS codes with associated modifiers
+    bcarrier_hcpcs_mods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            modifier_code
+        from (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pchcpcs,
+                modifier_1,
+                modifier_2
+            from bcarrier_base_data
+        ) mod_src
+        unpivot (
+            modifier_code for mod_position IN
+            (modifier_1, modifier_2)
+        ) as unpvt_mod
+        where pchcpcs is not null
+    ),
+    --HCPCS codes that have no modifier codes
+    bcarrier_hcpcs_nomods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from bcarrier_base_data
+        where pchcpcs is not null
+            and modifier_1 is null
+            and modifier_2 is null
+    ),
+    --BETOS codes
+    bcarrier_betos as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pcbetos as procedure_code,
+            null as modifier_code
+        from bcarrier_base_data
+        where pcbetos is not null
+    ),
+    --Final selection with deduplication via UNION
+    bcarrier_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from bcarrier_hcpcs_mods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from bcarrier_hcpcs_nomods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from bcarrier_betos
+    ),
+    
+    -------------------------
+    --Step 2: DME claims
+    --Yes: HCPCS codes with 4 modifier code fields
+    --Yes: BETOS codes
+    --No: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    dme_base_data as (
+    	select
+    	--top 100
+    	trim(a.bene_id) as id_mcare,
+    	trim(a.clm_id) as claim_header_id,
+    	cast(a.clm_from_dt as date) as first_service_date,
+    	cast(a.clm_thru_dt as date) as last_service_date,
+    	'dme' as filetype_mcare,
+    	b.hcpcs_cd as pchcpcs,
+    	b.hcpcs_1st_mdfr_cd as modifier_1,
+    	b.hcpcs_2nd_mdfr_cd as modifier_2,
+    	b.hcpcs_3rd_mdfr_cd as modifier_3,
+    	b.hcpcs_4th_mdfr_cd as modifier_4,
+    	b.betos_cd as pcbetos
+    	from stg_claims.mcare_dme_claims as a
+    	left join stg_claims.mcare_dme_line as b
+    	on a.clm_id = b.clm_id
+    	--exclude denined claims using carrier/dme claim method
+    	where a.carr_clm_pmt_dnl_cd in ('1','2','3','4','5','6','7','8','9')
+    ),
+    --HCPCS codes with associated modifiers
+    dme_hcpcs_mods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            modifier_code
+        from (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pchcpcs,
+                modifier_1,
+                modifier_2,
+    			modifier_3,
+    			modifier_4
+            from dme_base_data
+        ) mod_src
+        unpivot (
+            modifier_code for mod_position IN
+            (modifier_1, modifier_2, modifier_3, modifier_4)
+        ) as unpvt_mod
+        where pchcpcs is not null
+    ),
+    --HCPCS codes that have no modifier codes
+    dme_hcpcs_nomods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from dme_base_data
+        where pchcpcs is not null
+            and modifier_1 is null
+            and modifier_2 is null
+    		and modifier_3 is null
+    		and modifier_4 is null
+    ),
+    --BETOS codes
+    dme_betos as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pcbetos as procedure_code,
+            null as modifier_code
+        from dme_base_data
+        where pcbetos is not null
+    ),
+    --Final selection with deduplication via UNION
+    dme_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from dme_hcpcs_mods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from dme_hcpcs_nomods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from dme_betos
+    ),
+    
+    -------------------------
+    --Step 3: HHA claims
+    --Yes: HCPCS codes with 3 modifier code fields
+    --No: BETOS codes
+    --No: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    hha_base_data as (
+    	select
+    	--top 100
+    	trim(a.bene_id) as id_mcare,
+    	trim(a.clm_id) as claim_header_id,
+    	cast(a.clm_from_dt as date) as first_service_date,
+    	cast(a.clm_thru_dt as date) as last_service_date,
+    	b.hcpcs_cd as pchcpcs,
+    	case when (b.hcpcs_1st_mdfr_cd is null or b.hcpcs_1st_mdfr_cd = ' ') then null else b.hcpcs_1st_mdfr_cd end as modifier_1,
+    	case when (b.hcpcs_2nd_mdfr_cd is null or b.hcpcs_2nd_mdfr_cd = ' ') then null else b.hcpcs_2nd_mdfr_cd end as modifier_2,
+    	case when (b.hcpcs_3rd_mdfr_cd is null or b.hcpcs_3rd_mdfr_cd = ' ') then null else b.hcpcs_3rd_mdfr_cd end as modifier_3,
+    	'hha' as filetype_mcare,
+    	getdate() as last_run
+    	from stg_claims.mcare_hha_base_claims as a
+    	left join stg_claims.mcare_hha_revenue_center as b
+    	on a.clm_id = b.clm_id
+    	--exclude denined claims using facility claim method
+    	where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
+    ),
+    --HCPCS codes with associated modifiers
+    hha_hcpcs_mods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            modifier_code
+        from (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pchcpcs,
+                modifier_1,
+                modifier_2,
+    			modifier_3
+            from hha_base_data
+        ) mod_src
+        unpivot (
+            modifier_code for mod_position IN
+            (modifier_1, modifier_2, modifier_3)
+        ) as unpvt_mod
+        where pchcpcs is not null
+    ),
+    --HCPCS codes that have no modifier codes
+    hha_hcpcs_nomods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from hha_base_data
+        where pchcpcs is not null
+            and modifier_1 is null
+            and modifier_2 is null
+    		and modifier_3 is null
+    ),
+    --Final selection with deduplication via UNION
+    hha_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from hha_hcpcs_mods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from hha_hcpcs_nomods
+    ),
+    
+    -------------------------
+    --Step 4: Hospice claims
+    --Yes: HCPCS codes with 3 modifier code fields
+    --No: BETOS codes
+    --No: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    hospice_base_data as (
         select
         --top 100
-      	trim(a.bene_id) as id_mcare,
-      	trim(a.clm_id) as claim_header_id,
-      	cast(a.clm_from_dt as date) as first_service_date,
-      	cast(a.clm_thru_dt as date) as last_service_date,
-        b.hcpcs_cd as procedure_code,
-        'hcpcs' as procedure_code_number,
+        trim(a.bene_id) as id_mcare,
+        trim(a.clm_id) as claim_header_id,
+        cast(a.clm_from_dt as date) as first_service_date,
+        cast(a.clm_thru_dt as date) as last_service_date,
+        b.hcpcs_cd as pchcpcs,
         case when (b.hcpcs_1st_mdfr_cd is null or b.hcpcs_1st_mdfr_cd = ' ') then null else b.hcpcs_1st_mdfr_cd end as modifier_1,
         case when (b.hcpcs_2nd_mdfr_cd is null or b.hcpcs_2nd_mdfr_cd = ' ') then null else b.hcpcs_2nd_mdfr_cd end as modifier_2,
         case when (b.hcpcs_3rd_mdfr_cd is null or b.hcpcs_3rd_mdfr_cd = ' ') then null else b.hcpcs_3rd_mdfr_cd end as modifier_3,
-        modifier_4 = null,
         'hospice' as filetype_mcare,
         getdate() as last_run
         from stg_claims.mcare_hospice_base_claims as a
@@ -172,496 +389,889 @@ load_stage.mcare_claim_procedure_f <- function() {
         on a.clm_id = b.clm_id
         --exclude denined claims using facility claim method
         where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
-        	   	  
-        --inpatient
-        union
+    ),
+    --HCPCS codes with associated modifiers
+    hospice_hcpcs_mods as (
         select
-        id_mcare,
-        claim_header_id,
-        first_service_date,
-        last_service_date,
-        procedure_codes as 'procedure_code',
-        cast(substring(procedure_code_number, 3,10) as varchar(200)) as 'procedure_code_number',
-        case when (procedure_code_hcps_modifier_1 is null or procedure_code_hcps_modifier_1 = ' ') then null else procedure_code_hcps_modifier_1 end as modifier_1,
-        case when (procedure_code_hcps_modifier_2 is null or procedure_code_hcps_modifier_2 = ' ') then null else procedure_code_hcps_modifier_2 end as modifier_2,
-        case when (procedure_code_hcps_modifier_3 is null or procedure_code_hcps_modifier_3 = ' ') then null else procedure_code_hcps_modifier_3 end as modifier_3,
-        case when (procedure_code_hcps_modifier_4 is null or procedure_code_hcps_modifier_4 = ' ') then null else procedure_code_hcps_modifier_4 end as modifier_4,
-        filetype_mcare,
-        getdate() as last_run
-        
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            modifier_code
         from (
-        	select
-        	--top 100
-      		trim(a.bene_id) as id_mcare,
-      		trim(a.clm_id) as claim_header_id,
-      		cast(a.clm_from_dt as date) as first_service_date,
-      		cast(a.clm_thru_dt as date) as last_service_date,
-        	'inpatient' as filetype_mcare,
-        	b.hcpcs_cd as pchcpcs,
-        	b.hcpcs_1st_mdfr_cd as procedure_code_hcps_modifier_1,
-        	b.hcpcs_2nd_mdfr_cd as procedure_code_hcps_modifier_2,
-        	b.hcpcs_3rd_mdfr_cd as procedure_code_hcps_modifier_3,
-        	procedure_code_hcps_modifier_4 = null,
-      		a.icd_prcdr_cd1 as pc01,
-      		a.icd_prcdr_cd2 as pc02,
-      		a.icd_prcdr_cd3 as pc03,
-      		a.icd_prcdr_cd4 as pc04,
-      		a.icd_prcdr_cd5 as pc05,
-      		a.icd_prcdr_cd6 as pc06,
-      		a.icd_prcdr_cd7 as pc07,
-      		a.icd_prcdr_cd8 as pc08,
-      		a.icd_prcdr_cd9 as pc09,
-      		a.icd_prcdr_cd10 as pc10,
-      		a.icd_prcdr_cd11 as pc11,
-      		a.icd_prcdr_cd12 as pc12,
-      		a.icd_prcdr_cd13 as pc13,
-      		a.icd_prcdr_cd14 as pc14,
-      		a.icd_prcdr_cd15 as pc15,
-      		a.icd_prcdr_cd16 as pc16,
-      		a.icd_prcdr_cd17 as pc17,
-      		a.icd_prcdr_cd18 as pc18,
-      		a.icd_prcdr_cd19 as pc19,
-      		a.icd_prcdr_cd20 as pc20,
-      		a.icd_prcdr_cd21 as pc21,
-      		a.icd_prcdr_cd22 as pc22,
-      		a.icd_prcdr_cd23 as pc23,
-      		a.icd_prcdr_cd24 as pc24,
-      		a.icd_prcdr_cd25 as pc25
-        	from stg_claims.mcare_inpatient_base_claims as a
-        	left join stg_claims.mcare_inpatient_revenue_center as b
-        	on a.clm_id = b.clm_id
-    		--exclude denined claims using facility claim method
-    		where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
-        ) as x3
-        
-        --reshape from wide to long
-        unpivot(procedure_codes for procedure_code_number in (
-        	pchcpcs,
-        	pc01,
-        	pc02,
-        	pc03,
-        	pc04,
-        	pc05,
-        	pc06,
-        	pc07,
-        	pc08,
-        	pc09,
-        	pc10,
-        	pc11,
-        	pc12,
-        	pc13,
-        	pc14,
-        	pc15,
-        	pc16,
-        	pc17,
-        	pc18,
-        	pc19,
-        	pc20,
-        	pc21,
-        	pc22,
-        	pc23,
-        	pc24,
-        	pc25)
-        ) as procedure_codes
-        where procedure_codes is not null AND procedure_codes!=' '
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pchcpcs,
+                modifier_1,
+                modifier_2,
+    			modifier_3
+            from hospice_base_data
+        ) mod_src
+        unpivot (
+            modifier_code for mod_position IN
+            (modifier_1, modifier_2, modifier_3)
+        ) as unpvt_mod
+        where pchcpcs is not null
+    ),
+    --HCPCS codes that have no modifier codes
+    hospice_hcpcs_nomods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from hospice_base_data
+        where pchcpcs is not null
+            and modifier_1 is null
+            and modifier_2 is null
+    		and modifier_3 is null
+    ),
+    --Final selection with deduplication via UNION
+    hospice_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from hospice_hcpcs_mods
     
-    	--inpatient data structure j
-        union
-        select
-        id_mcare,
-        claim_header_id,
-        first_service_date,
-        last_service_date,
-        procedure_codes as 'procedure_code',
-        cast(substring(procedure_code_number, 3,10) as varchar(200)) as 'procedure_code_number',
-        case when (procedure_code_hcps_modifier_1 is null or procedure_code_hcps_modifier_1 = ' ') then null else procedure_code_hcps_modifier_1 end as modifier_1,
-        case when (procedure_code_hcps_modifier_2 is null or procedure_code_hcps_modifier_2 = ' ') then null else procedure_code_hcps_modifier_2 end as modifier_2,
-        case when (procedure_code_hcps_modifier_3 is null or procedure_code_hcps_modifier_3 = ' ') then null else procedure_code_hcps_modifier_3 end as modifier_3,
-        case when (procedure_code_hcps_modifier_4 is null or procedure_code_hcps_modifier_4 = ' ') then null else procedure_code_hcps_modifier_4 end as modifier_4,
-        filetype_mcare,
-        getdate() as last_run
-        
-        from (
-        	select
-        	--top 100
-      		trim(a.bene_id) as id_mcare,
-      		trim(a.clm_id) as claim_header_id,
-      		cast(a.clm_from_dt as date) as first_service_date,
-      		cast(a.clm_thru_dt as date) as last_service_date,
-        	'inpatient' as filetype_mcare,
-        	b.hcpcs_cd as pchcpcs,
-        	procedure_code_hcps_modifier_1 = null,
-        	procedure_code_hcps_modifier_2 = null,
-        	procedure_code_hcps_modifier_3 = null,
-        	procedure_code_hcps_modifier_4 = null,
-      		a.icd_prcdr_cd1 as pc01,
-      		a.icd_prcdr_cd2 as pc02,
-      		a.icd_prcdr_cd3 as pc03,
-      		a.icd_prcdr_cd4 as pc04,
-      		a.icd_prcdr_cd5 as pc05,
-      		a.icd_prcdr_cd6 as pc06,
-      		a.icd_prcdr_cd7 as pc07,
-      		a.icd_prcdr_cd8 as pc08,
-      		a.icd_prcdr_cd9 as pc09,
-      		a.icd_prcdr_cd10 as pc10,
-      		a.icd_prcdr_cd11 as pc11,
-      		a.icd_prcdr_cd12 as pc12,
-      		a.icd_prcdr_cd13 as pc13,
-      		a.icd_prcdr_cd14 as pc14,
-      		a.icd_prcdr_cd15 as pc15,
-      		a.icd_prcdr_cd16 as pc16,
-      		a.icd_prcdr_cd17 as pc17,
-      		a.icd_prcdr_cd18 as pc18,
-      		a.icd_prcdr_cd19 as pc19,
-      		a.icd_prcdr_cd20 as pc20,
-      		a.icd_prcdr_cd21 as pc21,
-      		a.icd_prcdr_cd22 as pc22,
-      		a.icd_prcdr_cd23 as pc23,
-      		a.icd_prcdr_cd24 as pc24,
-      		a.icd_prcdr_cd25 as pc25
-        	from stg_claims.mcare_inpatient_base_claims_j as a
-        	left join stg_claims.mcare_inpatient_revenue_center_j as b
-        	on a.clm_id = b.clm_id
-    		--exclude denined claims using facility claim method
-    		where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
-        ) as x4
-        
-        --reshape from wide to long
-        unpivot(procedure_codes for procedure_code_number in (
-        	pchcpcs,
-        	pc01,
-        	pc02,
-        	pc03,
-        	pc04,
-        	pc05,
-        	pc06,
-        	pc07,
-        	pc08,
-        	pc09,
-        	pc10,
-        	pc11,
-        	pc12,
-        	pc13,
-        	pc14,
-        	pc15,
-        	pc16,
-        	pc17,
-        	pc18,
-        	pc19,
-        	pc20,
-        	pc21,
-        	pc22,
-        	pc23,
-        	pc24,
-        	pc25)
-        ) as procedure_codes
-        where procedure_codes is not null AND procedure_codes!=' '
-        
-        --outpatient
-        union
-        select
-        id_mcare,
-        claim_header_id,
-        first_service_date,
-        last_service_date,
-        procedure_codes as 'procedure_code',
-        cast(substring(procedure_code_number, 3,10) as varchar(200)) as 'procedure_code_number',
-        case when (procedure_code_hcps_modifier_1 is null or procedure_code_hcps_modifier_1 = ' ') then null else procedure_code_hcps_modifier_1 end as modifier_1,
-        case when (procedure_code_hcps_modifier_2 is null or procedure_code_hcps_modifier_2 = ' ') then null else procedure_code_hcps_modifier_2 end as modifier_2,
-        case when (procedure_code_hcps_modifier_3 is null or procedure_code_hcps_modifier_3 = ' ') then null else procedure_code_hcps_modifier_3 end as modifier_3,
-        case when (procedure_code_hcps_modifier_4 is null or procedure_code_hcps_modifier_4 = ' ') then null else procedure_code_hcps_modifier_4 end as modifier_4,
-        filetype_mcare,
-        getdate() as last_run
-        
-        from (
-        	select
-        	--top 100
-      		trim(a.bene_id) as id_mcare,
-      		trim(a.clm_id) as claim_header_id,
-      		cast(a.clm_from_dt as date) as first_service_date,
-      		cast(a.clm_thru_dt as date) as last_service_date,
-        	'outpatient' as filetype_mcare,
-        	b.hcpcs_cd as pchcpcs,
-        	b.hcpcs_1st_mdfr_cd as procedure_code_hcps_modifier_1,
-        	b.hcpcs_2nd_mdfr_cd as procedure_code_hcps_modifier_2,
-        	b.hcpcs_3rd_mdfr_cd as procedure_code_hcps_modifier_3,
-      		b.hcpcs_4th_mdfr_cd as procedure_code_hcps_modifier_4,
-      		a.icd_prcdr_cd1 as pc01,
-      		a.icd_prcdr_cd2 as pc02,
-      		a.icd_prcdr_cd3 as pc03,
-      		a.icd_prcdr_cd4 as pc04,
-      		a.icd_prcdr_cd5 as pc05,
-      		a.icd_prcdr_cd6 as pc06,
-      		a.icd_prcdr_cd7 as pc07,
-      		a.icd_prcdr_cd8 as pc08,
-      		a.icd_prcdr_cd9 as pc09,
-      		a.icd_prcdr_cd10 as pc10,
-      		a.icd_prcdr_cd11 as pc11,
-      		a.icd_prcdr_cd12 as pc12,
-      		a.icd_prcdr_cd13 as pc13,
-      		a.icd_prcdr_cd14 as pc14,
-      		a.icd_prcdr_cd15 as pc15,
-      		a.icd_prcdr_cd16 as pc16,
-      		a.icd_prcdr_cd17 as pc17,
-      		a.icd_prcdr_cd18 as pc18,
-      		a.icd_prcdr_cd19 as pc19,
-      		a.icd_prcdr_cd20 as pc20,
-      		a.icd_prcdr_cd21 as pc21,
-      		a.icd_prcdr_cd22 as pc22,
-      		a.icd_prcdr_cd23 as pc23,
-      		a.icd_prcdr_cd24 as pc24,
-      		a.icd_prcdr_cd25 as pc25
-        	from stg_claims.mcare_outpatient_base_claims as a
-        	left join stg_claims.mcare_outpatient_revenue_center as b
-        	on a.clm_id = b.clm_id
-    		--exclude denined claims using facility claim method
-    		where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
-        ) as x5
-        
-        --reshape from wide to long
-        unpivot(procedure_codes for procedure_code_number in (
-        	pchcpcs,
-        	pc01,
-        	pc02,
-        	pc03,
-        	pc04,
-        	pc05,
-        	pc06,
-        	pc07,
-        	pc08,
-        	pc09,
-        	pc10,
-        	pc11,
-        	pc12,
-        	pc13,
-        	pc14,
-        	pc15,
-        	pc16,
-        	pc17,
-        	pc18,
-        	pc19,
-        	pc20,
-        	pc21,
-        	pc22,
-        	pc23,
-        	pc24,
-        	pc25)
-        ) as procedure_codes
-        where procedure_codes is not null AND procedure_codes!=' '
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from hospice_hcpcs_nomods
+    ),
     
-    	--outpatient data structure j
-        union
+    -------------------------
+    --Step 5: Inpatient claims, current vintage
+    --Yes: HCPCS codes with 3 modifier code fields
+    --No: BETOS codes
+    --Yes: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    inpatient_base_data as (
+    	select
+    	--top 100
+    	trim(a.bene_id) as id_mcare,
+    	trim(a.clm_id) as claim_header_id,
+    	cast(a.clm_from_dt as date) as first_service_date,
+    	cast(a.clm_thru_dt as date) as last_service_date,
+    	'inpatient' as filetype_mcare,
+    	b.hcpcs_cd as pchcpcs,
+    	b.hcpcs_1st_mdfr_cd as modifier_1,
+    	b.hcpcs_2nd_mdfr_cd as modifier_2,
+    	b.hcpcs_3rd_mdfr_cd as modifier_3,
+    	a.icd_prcdr_cd1 as pc01,
+    	a.icd_prcdr_cd2 as pc02,
+    	a.icd_prcdr_cd3 as pc03,
+    	a.icd_prcdr_cd4 as pc04,
+    	a.icd_prcdr_cd5 as pc05,
+    	a.icd_prcdr_cd6 as pc06,
+    	a.icd_prcdr_cd7 as pc07,
+    	a.icd_prcdr_cd8 as pc08,
+    	a.icd_prcdr_cd9 as pc09,
+    	a.icd_prcdr_cd10 as pc10,
+    	a.icd_prcdr_cd11 as pc11,
+    	a.icd_prcdr_cd12 as pc12,
+    	a.icd_prcdr_cd13 as pc13,
+    	a.icd_prcdr_cd14 as pc14,
+    	a.icd_prcdr_cd15 as pc15,
+    	a.icd_prcdr_cd16 as pc16,
+    	a.icd_prcdr_cd17 as pc17,
+    	a.icd_prcdr_cd18 as pc18,
+    	a.icd_prcdr_cd19 as pc19,
+    	a.icd_prcdr_cd20 as pc20,
+    	a.icd_prcdr_cd21 as pc21,
+    	a.icd_prcdr_cd22 as pc22,
+    	a.icd_prcdr_cd23 as pc23,
+    	a.icd_prcdr_cd24 as pc24,
+    	a.icd_prcdr_cd25 as pc25
+    	from stg_claims.mcare_inpatient_base_claims as a
+    	left join stg_claims.mcare_inpatient_revenue_center as b
+    	on a.clm_id = b.clm_id
+    	--exclude denined claims using facility claim method
+    	where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
+    ),
+    --HCPCS codes with associated modifiers
+    inpatient_hcpcs_mods as (
         select
-        id_mcare,
-        claim_header_id,
-        first_service_date,
-        last_service_date,
-        procedure_codes as 'procedure_code',
-        cast(substring(procedure_code_number, 3,10) as varchar(200)) as 'procedure_code_number',
-        case when (procedure_code_hcps_modifier_1 is null or procedure_code_hcps_modifier_1 = ' ') then null else procedure_code_hcps_modifier_1 end as modifier_1,
-        case when (procedure_code_hcps_modifier_2 is null or procedure_code_hcps_modifier_2 = ' ') then null else procedure_code_hcps_modifier_2 end as modifier_2,
-        case when (procedure_code_hcps_modifier_3 is null or procedure_code_hcps_modifier_3 = ' ') then null else procedure_code_hcps_modifier_3 end as modifier_3,
-        case when (procedure_code_hcps_modifier_4 is null or procedure_code_hcps_modifier_4 = ' ') then null else procedure_code_hcps_modifier_4 end as modifier_4,
-        filetype_mcare,
-        getdate() as last_run
-        
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            modifier_code
         from (
-        	select
-        	--top 100
-      		trim(a.bene_id) as id_mcare,
-      		trim(a.clm_id) as claim_header_id,
-      		cast(a.clm_from_dt as date) as first_service_date,
-      		cast(a.clm_thru_dt as date) as last_service_date,
-        	'outpatient' as filetype_mcare,
-        	b.hcpcs_cd as pchcpcs,
-        	b.hcpcs_1st_mdfr_cd as procedure_code_hcps_modifier_1,
-        	b.hcpcs_2nd_mdfr_cd as procedure_code_hcps_modifier_2,
-        	procedure_code_hcps_modifier_3 = null,
-      		procedure_code_hcps_modifier_4 = null,
-      		a.icd_prcdr_cd1 as pc01,
-      		a.icd_prcdr_cd2 as pc02,
-      		a.icd_prcdr_cd3 as pc03,
-      		a.icd_prcdr_cd4 as pc04,
-      		a.icd_prcdr_cd5 as pc05,
-      		a.icd_prcdr_cd6 as pc06,
-      		a.icd_prcdr_cd7 as pc07,
-      		a.icd_prcdr_cd8 as pc08,
-      		a.icd_prcdr_cd9 as pc09,
-      		a.icd_prcdr_cd10 as pc10,
-      		a.icd_prcdr_cd11 as pc11,
-      		a.icd_prcdr_cd12 as pc12,
-      		a.icd_prcdr_cd13 as pc13,
-      		a.icd_prcdr_cd14 as pc14,
-      		a.icd_prcdr_cd15 as pc15,
-      		a.icd_prcdr_cd16 as pc16,
-      		a.icd_prcdr_cd17 as pc17,
-      		a.icd_prcdr_cd18 as pc18,
-      		a.icd_prcdr_cd19 as pc19,
-      		a.icd_prcdr_cd20 as pc20,
-      		a.icd_prcdr_cd21 as pc21,
-      		a.icd_prcdr_cd22 as pc22,
-      		a.icd_prcdr_cd23 as pc23,
-      		a.icd_prcdr_cd24 as pc24,
-      		a.icd_prcdr_cd25 as pc25
-        	from stg_claims.mcare_outpatient_base_claims_j as a
-        	left join stg_claims.mcare_outpatient_revenue_center_j as b
-        	on a.clm_id = b.clm_id
-    		--exclude denined claims using facility claim method
-    		where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
-        ) as x6
-        
-        --reshape from wide to long
-        unpivot(procedure_codes for procedure_code_number in (
-        	pchcpcs,
-        	pc01,
-        	pc02,
-        	pc03,
-        	pc04,
-        	pc05,
-        	pc06,
-        	pc07,
-        	pc08,
-        	pc09,
-        	pc10,
-        	pc11,
-        	pc12,
-        	pc13,
-        	pc14,
-        	pc15,
-        	pc16,
-        	pc17,
-        	pc18,
-        	pc19,
-        	pc20,
-        	pc21,
-        	pc22,
-        	pc23,
-        	pc24,
-        	pc25)
-        ) as procedure_codes
-        where procedure_codes is not null AND procedure_codes!=' '
-        
-        --snf
-        union
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pchcpcs,
+                modifier_1,
+                modifier_2,
+    			modifier_3
+            from inpatient_base_data
+        ) mod_src
+        unpivot (
+            modifier_code for mod_position IN
+            (modifier_1, modifier_2, modifier_3)
+        ) as unpvt_mod
+        where pchcpcs is not null
+    ),
+    --HCPCS codes that have no modifier codes
+    inpatient_hcpcs_nomods as (
         select
-        id_mcare,
-        claim_header_id,
-        first_service_date,
-        last_service_date,
-        procedure_codes as 'procedure_code',
-        cast(substring(procedure_code_number, 3,10) as varchar(200)) as 'procedure_code_number',
-        case when (procedure_code_hcps_modifier_1 is null or procedure_code_hcps_modifier_1 = ' ') then null else procedure_code_hcps_modifier_1 end as modifier_1,
-        case when (procedure_code_hcps_modifier_2 is null or procedure_code_hcps_modifier_2 = ' ') then null else procedure_code_hcps_modifier_2 end as modifier_2,
-        case when (procedure_code_hcps_modifier_3 is null or procedure_code_hcps_modifier_3 = ' ') then null else procedure_code_hcps_modifier_3 end as modifier_3,
-        case when (procedure_code_hcps_modifier_4 is null or procedure_code_hcps_modifier_4 = ' ') then null else procedure_code_hcps_modifier_4 end as modifier_4,
-        filetype_mcare,
-        getdate() as last_run
-        
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from inpatient_base_data
+        where pchcpcs is not null
+            and modifier_1 is null
+            and modifier_2 is null
+    		and modifier_3 is null
+    ),
+    --ICD-PCS codes
+    inpatient_icdpcs as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            procedure_code,
+            null as modifier_code
+        FROM (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    			pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25
+            from inpatient_base_data
+        ) icdpcs
+        unpivot (
+            procedure_code FOR code_position IN
+            (pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    		 pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25)
+        ) as unpvt_icdpcs
+    	where procedure_code is not null AND procedure_code != ' '
+    ),
+    --Final selection with deduplication via UNION
+    inpatient_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from inpatient_hcpcs_mods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from inpatient_hcpcs_nomods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from inpatient_icdpcs
+    ),
+    
+    -------------------------
+    --Step 6: Inpatient claims, vintage J
+    --Yes: HCPCS codes with 0 modifier code fields
+    --No: BETOS codes
+    --Yes: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    inpatientj_base_data as (
+    	select
+    	--top 100
+    	trim(a.bene_id) as id_mcare,
+    	trim(a.clm_id) as claim_header_id,
+    	cast(a.clm_from_dt as date) as first_service_date,
+    	cast(a.clm_thru_dt as date) as last_service_date,
+    	'inpatient' as filetype_mcare,
+    	b.hcpcs_cd as pchcpcs,
+    	a.icd_prcdr_cd1 as pc01,
+    	a.icd_prcdr_cd2 as pc02,
+    	a.icd_prcdr_cd3 as pc03,
+    	a.icd_prcdr_cd4 as pc04,
+    	a.icd_prcdr_cd5 as pc05,
+    	a.icd_prcdr_cd6 as pc06,
+    	a.icd_prcdr_cd7 as pc07,
+    	a.icd_prcdr_cd8 as pc08,
+    	a.icd_prcdr_cd9 as pc09,
+    	a.icd_prcdr_cd10 as pc10,
+    	a.icd_prcdr_cd11 as pc11,
+    	a.icd_prcdr_cd12 as pc12,
+    	a.icd_prcdr_cd13 as pc13,
+    	a.icd_prcdr_cd14 as pc14,
+    	a.icd_prcdr_cd15 as pc15,
+    	a.icd_prcdr_cd16 as pc16,
+    	a.icd_prcdr_cd17 as pc17,
+    	a.icd_prcdr_cd18 as pc18,
+    	a.icd_prcdr_cd19 as pc19,
+    	a.icd_prcdr_cd20 as pc20,
+    	a.icd_prcdr_cd21 as pc21,
+    	a.icd_prcdr_cd22 as pc22,
+    	a.icd_prcdr_cd23 as pc23,
+    	a.icd_prcdr_cd24 as pc24,
+    	a.icd_prcdr_cd25 as pc25
+    	from stg_claims.mcare_inpatient_base_claims_j as a
+    	left join stg_claims.mcare_inpatient_revenue_center_j as b
+    	on a.clm_id = b.clm_id
+    	--exclude denined claims using facility claim method
+    	where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
+    ),
+    --All HCPCS codes
+    inpatientj_hcpcs as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from inpatientj_base_data
+        where pchcpcs is not null
+    ),
+    --ICD-PCS codes
+    inpatientj_icdpcs as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            procedure_code,
+            null as modifier_code
+        FROM (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    			pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25
+            from inpatientj_base_data
+        ) icdpcs
+        unpivot (
+            procedure_code FOR code_position IN
+            (pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    		 pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25)
+        ) as unpvt_icdpcs
+    	where procedure_code is not null AND procedure_code != ' '
+    ),
+    --Final selection with deduplication via UNION
+    inpatientj_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from inpatientj_hcpcs
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from inpatientj_icdpcs
+    ),
+    
+    -------------------------
+    --Step 7: Outpatient claims, current vintage
+    --Yes: HCPCS codes with 4 modifier code fields
+    --No: BETOS codes
+    --Yes: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    outpatient_base_data as (
+    	select
+    	--top 100
+    	trim(a.bene_id) as id_mcare,
+    	trim(a.clm_id) as claim_header_id,
+    	cast(a.clm_from_dt as date) as first_service_date,
+    	cast(a.clm_thru_dt as date) as last_service_date,
+    	'outpatient' as filetype_mcare,
+    	b.hcpcs_cd as pchcpcs,
+    	b.hcpcs_1st_mdfr_cd as modifier_1,
+    	b.hcpcs_2nd_mdfr_cd as modifier_2,
+    	b.hcpcs_3rd_mdfr_cd as modifier_3,
+    	b.hcpcs_4th_mdfr_cd as modifier_4,
+    	a.icd_prcdr_cd1 as pc01,
+    	a.icd_prcdr_cd2 as pc02,
+    	a.icd_prcdr_cd3 as pc03,
+    	a.icd_prcdr_cd4 as pc04,
+    	a.icd_prcdr_cd5 as pc05,
+    	a.icd_prcdr_cd6 as pc06,
+    	a.icd_prcdr_cd7 as pc07,
+    	a.icd_prcdr_cd8 as pc08,
+    	a.icd_prcdr_cd9 as pc09,
+    	a.icd_prcdr_cd10 as pc10,
+    	a.icd_prcdr_cd11 as pc11,
+    	a.icd_prcdr_cd12 as pc12,
+    	a.icd_prcdr_cd13 as pc13,
+    	a.icd_prcdr_cd14 as pc14,
+    	a.icd_prcdr_cd15 as pc15,
+    	a.icd_prcdr_cd16 as pc16,
+    	a.icd_prcdr_cd17 as pc17,
+    	a.icd_prcdr_cd18 as pc18,
+    	a.icd_prcdr_cd19 as pc19,
+    	a.icd_prcdr_cd20 as pc20,
+    	a.icd_prcdr_cd21 as pc21,
+    	a.icd_prcdr_cd22 as pc22,
+    	a.icd_prcdr_cd23 as pc23,
+    	a.icd_prcdr_cd24 as pc24,
+    	a.icd_prcdr_cd25 as pc25
+    	from stg_claims.mcare_outpatient_base_claims as a
+    	left join stg_claims.mcare_outpatient_revenue_center as b
+    	on a.clm_id = b.clm_id
+    	--exclude denined claims using facility claim method
+    	where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
+    ),
+    --HCPCS codes with associated modifiers
+    outpatient_hcpcs_mods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            modifier_code
         from (
-        	select
-        	--top 100
-      		trim(a.bene_id) as id_mcare,
-      		trim(a.clm_id) as claim_header_id,
-      		cast(a.clm_from_dt as date) as first_service_date,
-      		cast(a.clm_thru_dt as date) as last_service_date,
-        	'snf' as filetype_mcare,
-        	b.hcpcs_cd as pchcpcs,
-        	b.hcpcs_1st_mdfr_cd as procedure_code_hcps_modifier_1,
-        	b.hcpcs_2nd_mdfr_cd as procedure_code_hcps_modifier_2,
-        	b.hcpcs_3rd_mdfr_cd as procedure_code_hcps_modifier_3,
-        	procedure_code_hcps_modifier_4 = null,
-      		a.icd_prcdr_cd1 as pc01,
-      		a.icd_prcdr_cd2 as pc02,
-      		a.icd_prcdr_cd3 as pc03,
-      		a.icd_prcdr_cd4 as pc04,
-      		a.icd_prcdr_cd5 as pc05,
-      		a.icd_prcdr_cd6 as pc06,
-      		a.icd_prcdr_cd7 as pc07,
-      		a.icd_prcdr_cd8 as pc08,
-      		a.icd_prcdr_cd9 as pc09,
-      		a.icd_prcdr_cd10 as pc10,
-      		a.icd_prcdr_cd11 as pc11,
-      		a.icd_prcdr_cd12 as pc12,
-      		a.icd_prcdr_cd13 as pc13,
-      		a.icd_prcdr_cd14 as pc14,
-      		a.icd_prcdr_cd15 as pc15,
-      		a.icd_prcdr_cd16 as pc16,
-      		a.icd_prcdr_cd17 as pc17,
-      		a.icd_prcdr_cd18 as pc18,
-      		a.icd_prcdr_cd19 as pc19,
-      		a.icd_prcdr_cd20 as pc20,
-      		a.icd_prcdr_cd21 as pc21,
-      		a.icd_prcdr_cd22 as pc22,
-      		a.icd_prcdr_cd23 as pc23,
-      		a.icd_prcdr_cd24 as pc24,
-      		a.icd_prcdr_cd25 as pc25
-        	from stg_claims.mcare_snf_base_claims as a
-        	left join stg_claims.mcare_snf_revenue_center as b
-        	on a.clm_id = b.clm_id
-    		--exclude denined claims using facility claim method
-    		where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
-        ) as x7
-        
-        --reshape from wide to long
-        unpivot(procedure_codes for procedure_code_number in (
-        	pchcpcs,
-        	pc01,
-        	pc02,
-        	pc03,
-        	pc04,
-        	pc05,
-        	pc06,
-        	pc07,
-        	pc08,
-        	pc09,
-        	pc10,
-        	pc11,
-        	pc12,
-        	pc13,
-        	pc14,
-        	pc15,
-        	pc16,
-        	pc17,
-        	pc18,
-        	pc19,
-        	pc20,
-        	pc21,
-        	pc22,
-        	pc23,
-        	pc24,
-        	pc25)
-        ) as procedure_codes
-        where procedure_codes is not null AND procedure_codes!=' '
-        	
-    ) as z
-    --exclude claims among people who have no eligibility data
-    left join stg_claims.mcare_bene_enrollment as w
-    on z.id_mcare = w.bene_id
-    where w.bene_id is not null;",
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pchcpcs,
+                modifier_1,
+                modifier_2,
+    			modifier_3,
+    			modifier_4
+            from outpatient_base_data
+        ) mod_src
+        unpivot (
+            modifier_code for mod_position IN
+            (modifier_1, modifier_2, modifier_3, modifier_4)
+        ) as unpvt_mod
+        where pchcpcs is not null
+    ),
+    --HCPCS codes that have no modifier codes
+    outpatient_hcpcs_nomods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from outpatient_base_data
+        where pchcpcs is not null
+            and modifier_1 is null
+            and modifier_2 is null
+    		and modifier_3 is null
+    		and modifier_4 is null
+    ),
+    --ICD-PCS codes
+    outpatient_icdpcs as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            procedure_code,
+            null as modifier_code
+        FROM (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    			pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25
+            from outpatient_base_data
+        ) icdpcs
+        unpivot (
+            procedure_code FOR code_position IN
+            (pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    		 pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25)
+        ) as unpvt_icdpcs
+    	where procedure_code is not null AND procedure_code != ' '
+    ),
+    --Final selection with deduplication via UNION
+    outpatient_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from outpatient_hcpcs_mods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from outpatient_hcpcs_nomods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from outpatient_icdpcs
+    ),
+    
+    -------------------------
+    --Step 8: Outpatient claims, vintage J
+    --Yes: HCPCS codes with 2 modifier code fields
+    --No: BETOS codes
+    --Yes: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    outpatientj_base_data as (
+    	select
+    	--top 100
+    	trim(a.bene_id) as id_mcare,
+    	trim(a.clm_id) as claim_header_id,
+    	cast(a.clm_from_dt as date) as first_service_date,
+    	cast(a.clm_thru_dt as date) as last_service_date,
+    	'outpatient' as filetype_mcare,
+    	b.hcpcs_cd as pchcpcs,
+    	b.hcpcs_1st_mdfr_cd as modifier_1,
+    	b.hcpcs_2nd_mdfr_cd as modifier_2,
+    	a.icd_prcdr_cd1 as pc01,
+    	a.icd_prcdr_cd2 as pc02,
+    	a.icd_prcdr_cd3 as pc03,
+    	a.icd_prcdr_cd4 as pc04,
+    	a.icd_prcdr_cd5 as pc05,
+    	a.icd_prcdr_cd6 as pc06,
+    	a.icd_prcdr_cd7 as pc07,
+    	a.icd_prcdr_cd8 as pc08,
+    	a.icd_prcdr_cd9 as pc09,
+    	a.icd_prcdr_cd10 as pc10,
+    	a.icd_prcdr_cd11 as pc11,
+    	a.icd_prcdr_cd12 as pc12,
+    	a.icd_prcdr_cd13 as pc13,
+    	a.icd_prcdr_cd14 as pc14,
+    	a.icd_prcdr_cd15 as pc15,
+    	a.icd_prcdr_cd16 as pc16,
+    	a.icd_prcdr_cd17 as pc17,
+    	a.icd_prcdr_cd18 as pc18,
+    	a.icd_prcdr_cd19 as pc19,
+    	a.icd_prcdr_cd20 as pc20,
+    	a.icd_prcdr_cd21 as pc21,
+    	a.icd_prcdr_cd22 as pc22,
+    	a.icd_prcdr_cd23 as pc23,
+    	a.icd_prcdr_cd24 as pc24,
+    	a.icd_prcdr_cd25 as pc25
+    	from stg_claims.mcare_outpatient_base_claims_j as a
+    	left join stg_claims.mcare_outpatient_revenue_center_j as b
+    	on a.clm_id = b.clm_id
+    	--exclude denined claims using facility claim method
+    	where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
+    ),
+    --HCPCS codes with associated modifiers
+    outpatientj_hcpcs_mods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            modifier_code
+        from (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pchcpcs,
+                modifier_1,
+                modifier_2
+            from outpatientj_base_data
+        ) mod_src
+        unpivot (
+            modifier_code for mod_position IN
+            (modifier_1, modifier_2)
+        ) as unpvt_mod
+        where pchcpcs is not null
+    ),
+    --HCPCS codes that have no modifier codes
+    outpatientj_hcpcs_nomods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from outpatientj_base_data
+        where pchcpcs is not null
+            and modifier_1 is null
+            and modifier_2 is null
+    ),
+    --ICD-PCS codes
+    outpatientj_icdpcs as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            procedure_code,
+            null as modifier_code
+        FROM (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    			pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25
+            from outpatientj_base_data
+        ) icdpcs
+        unpivot (
+            procedure_code FOR code_position IN
+            (pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    		 pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25)
+        ) as unpvt_icdpcs
+    	where procedure_code is not null AND procedure_code != ' '
+    ),
+    --Final selection with deduplication via UNION
+    outpatientj_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from outpatientj_hcpcs_mods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from outpatientj_hcpcs_nomods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from outpatientj_icdpcs
+    ),
+    
+    -------------------------
+    --Step 9: SNF claims
+    --Yes: HCPCS codes with 3 modifier code fields
+    --No: BETOS codes
+    --Yes: ICD-PCS codes
+    -------------------------
+    
+    --Base CTE: pulled once from the source table
+    snf_base_data as (
+    	select
+    	--top 100
+    	trim(a.bene_id) as id_mcare,
+    	trim(a.clm_id) as claim_header_id,
+    	cast(a.clm_from_dt as date) as first_service_date,
+    	cast(a.clm_thru_dt as date) as last_service_date,
+    	'snf' as filetype_mcare,
+    	b.hcpcs_cd as pchcpcs,
+    	b.hcpcs_1st_mdfr_cd as modifier_1,
+    	b.hcpcs_2nd_mdfr_cd as modifier_2,
+    	b.hcpcs_3rd_mdfr_cd as modifier_3,
+    	a.icd_prcdr_cd1 as pc01,
+    	a.icd_prcdr_cd2 as pc02,
+    	a.icd_prcdr_cd3 as pc03,
+    	a.icd_prcdr_cd4 as pc04,
+    	a.icd_prcdr_cd5 as pc05,
+    	a.icd_prcdr_cd6 as pc06,
+    	a.icd_prcdr_cd7 as pc07,
+    	a.icd_prcdr_cd8 as pc08,
+    	a.icd_prcdr_cd9 as pc09,
+    	a.icd_prcdr_cd10 as pc10,
+    	a.icd_prcdr_cd11 as pc11,
+    	a.icd_prcdr_cd12 as pc12,
+    	a.icd_prcdr_cd13 as pc13,
+    	a.icd_prcdr_cd14 as pc14,
+    	a.icd_prcdr_cd15 as pc15,
+    	a.icd_prcdr_cd16 as pc16,
+    	a.icd_prcdr_cd17 as pc17,
+    	a.icd_prcdr_cd18 as pc18,
+    	a.icd_prcdr_cd19 as pc19,
+    	a.icd_prcdr_cd20 as pc20,
+    	a.icd_prcdr_cd21 as pc21,
+    	a.icd_prcdr_cd22 as pc22,
+    	a.icd_prcdr_cd23 as pc23,
+    	a.icd_prcdr_cd24 as pc24,
+    	a.icd_prcdr_cd25 as pc25
+    	from stg_claims.mcare_snf_base_claims as a
+    	left join stg_claims.mcare_snf_revenue_center as b
+    	on a.clm_id = b.clm_id
+    	--exclude denined claims using facility claim method
+    	where (a.clm_mdcr_non_pmt_rsn_cd = '' or a.clm_mdcr_non_pmt_rsn_cd is null)
+    ),
+    --HCPCS codes with associated modifiers
+    snf_hcpcs_mods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            modifier_code
+        from (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pchcpcs,
+                modifier_1,
+                modifier_2,
+    			modifier_3
+            from snf_base_data
+        ) mod_src
+        unpivot (
+            modifier_code for mod_position IN
+            (modifier_1, modifier_2, modifier_3)
+        ) as unpvt_mod
+        where pchcpcs is not null
+    ),
+    --HCPCS codes that have no modifier codes
+    snf_hcpcs_nomods as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            pchcpcs as procedure_code,
+            null as modifier_code
+        from snf_base_data
+        where pchcpcs is not null
+            and modifier_1 is null
+            and modifier_2 is null
+    		and modifier_3 is null
+    ),
+    --ICD-PCS codes
+    snf_icdpcs as (
+        select
+            id_mcare,
+            claim_header_id,
+            first_service_date,
+            last_service_date,
+    		filetype_mcare,
+            procedure_code,
+            null as modifier_code
+        FROM (
+            select
+                id_mcare,
+                claim_header_id,
+                first_service_date,
+                last_service_date,
+    			filetype_mcare,
+                pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    			pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25
+            from snf_base_data
+        ) icdpcs
+        unpivot (
+            procedure_code FOR code_position IN
+            (pc01, pc02, pc03, pc04, pc05, pc06, pc07, pc08, pc09, pc10, pc11, pc12, pc13,
+    		 pc14, pc15, pc16, pc17, pc18, pc19, pc20, pc21, pc22, pc23, pc24, pc25)
+        ) as unpvt_icdpcs
+    	where procedure_code is not null AND procedure_code != ' '
+    ),
+    --Final selection with deduplication via UNION
+    snf_final as (
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from snf_hcpcs_mods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from snf_hcpcs_nomods
+    
+    	union
+    	select
+    	id_mcare,
+    	claim_header_id,
+    	first_service_date,
+    	last_service_date,
+    	procedure_code,
+    	modifier_code,
+    	filetype_mcare,
+    	getdate() as last_run
+    	from snf_icdpcs
+    ),
+    
+    -------------------------
+    --Step 10: Union all claim types
+    -------------------------
+    final_union as (
+    select * from bcarrier_final
+    union select * from dme_final
+    union select * from hha_final
+    union select * from hospice_final
+    union select * from inpatient_final
+    union select * from inpatientj_final
+    union select * from outpatient_final
+    union select * from outpatientj_final
+    union select * from snf_final
+    )
+    
+    -------------------------
+    --Step 11: Exclude claims among people with no enrollment data and insert into table shell
+    -------------------------
+    select a.*
+    into stg_claims.stage_mcare_claim_procedure_dev --test code
+    from final_union as a
+    left join (select distinct bene_id from stg_claims.mcare_bene_enrollment) as b
+    on a.id_mcare = b.bene_id
+    where b.bene_id is not null;",
         .con = inthealth))
     }
 
 #### Table-level QA script ####
 qa_stage.mcare_claim_procedure_qa_f <- function() {
   
-  #confirm that claim types with hcpcs codes have data for each year
+  #confirm that claim types with hcpcs codes have data for each year (HCPCS codes are 5 digits long)
   res1 <- dbGetQuery(conn = inthealth, glue_sql(
     "select 'stg_claims.stage_mcare_claim_procedure' as 'table',
   'rows with non-null hcpcs code' as qa_type,
   filetype_mcare, year(last_service_date) as service_year, count(*) as qa
-  from stg_claims.stage_mcare_claim_procedure
-  where procedure_code is not null and procedure_code_number = 'hcpcs'
+  from stg_claims.stage_mcare_claim_procedure_dev
+  where procedure_code is not null and len(procedure_code) = 5
   group by filetype_mcare, year(last_service_date)
   order by filetype_mcare, year(last_service_date);",
     .con = inthealth))
   
-  #confirm that claim types with betos codes have data for each year
+  #confirm that claim types with betos codes have data for each year (BETOS codes are 2-3 digits long and start with letter)
   res2 <- dbGetQuery(conn = inthealth, glue_sql(
     "select 'stg_claims.stage_mcare_claim_procedure' as 'table',
   'rows with non-null betos code' as qa_type,
   filetype_mcare, year(last_service_date) as service_year, count(*) as qa
-  from stg_claims.stage_mcare_claim_procedure
-  where procedure_code is not null and procedure_code_number = 'betos'
+  from stg_claims.stage_mcare_claim_procedure_dev
+  where procedure_code is not null and len(procedure_code) <= 3 and left(procedure_code, 1) like '[A-Z]'
   group by filetype_mcare, year(last_service_date)
   order by filetype_mcare, year(last_service_date);",
     .con = inthealth))
@@ -671,8 +1281,9 @@ qa_stage.mcare_claim_procedure_qa_f <- function() {
     "select 'stg_claims.stage_mcare_claim_procedure' as 'table',
   'rows with non-null ICD procedure code 1' as qa_type,
   filetype_mcare, year(last_service_date) as service_year, count(*) as qa
-  from stg_claims.stage_mcare_claim_procedure
-  where procedure_code is not null and procedure_code_number = '01'
+  from stg_claims.stage_mcare_claim_procedure_dev
+  where procedure_code is not null and 
+    (len(procedure_code) = 7 or (len(procedure_code) <=4 and left(procedure_code, 1) like '[0-9]'))
   group by filetype_mcare, year(last_service_date)
   order by filetype_mcare, year(last_service_date);",
     .con = inthealth))
@@ -681,7 +1292,7 @@ qa_stage.mcare_claim_procedure_qa_f <- function() {
   res4 <- dbGetQuery(conn = inthealth, glue_sql(
     "select 'stg_claims.stage_mcare_claim_procedure' as 'table', '# members not in bene_enrollment, expect 0' as qa_type,
     count(a.id_mcare) as qa
-    from stg_claims.stage_mcare_claim_procedure as a
+    from stg_claims.stage_mcare_claim_procedure_dev as a
     left join stg_claims.mcare_bene_enrollment as b
     on a.id_mcare = b.bene_id
     where b.bene_id is null;",

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.R
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.R
@@ -1242,7 +1242,7 @@ load_stage.mcare_claim_procedure_f <- function() {
     -------------------------
     --Step 11: Exclude claims among people with no enrollment data and insert into table shell
     -------------------------
-    insert into stg_claims.stage_mcare_claim_procedure_dev
+    insert into stg_claims.stage_mcare_claim_procedure
     select a.*
     from final_union as a
     left join (select distinct bene_id from stg_claims.mcare_bene_enrollment) as b
@@ -1259,7 +1259,7 @@ qa_stage.mcare_claim_procedure_qa_f <- function() {
     "select 'stg_claims.stage_mcare_claim_procedure' as 'table',
   'rows with non-null hcpcs code' as qa_type,
   filetype_mcare, year(last_service_date) as service_year, count(*) as qa
-  from stg_claims.stage_mcare_claim_procedure_dev
+  from stg_claims.stage_mcare_claim_procedure
   where procedure_code is not null and len(procedure_code) = 5
   group by filetype_mcare, year(last_service_date)
   order by filetype_mcare, year(last_service_date);",
@@ -1270,7 +1270,7 @@ qa_stage.mcare_claim_procedure_qa_f <- function() {
     "select 'stg_claims.stage_mcare_claim_procedure' as 'table',
   'rows with non-null betos code' as qa_type,
   filetype_mcare, year(last_service_date) as service_year, count(*) as qa
-  from stg_claims.stage_mcare_claim_procedure_dev
+  from stg_claims.stage_mcare_claim_procedure
   where procedure_code is not null and len(procedure_code) <= 3 and left(procedure_code, 1) like '[A-Z]'
   group by filetype_mcare, year(last_service_date)
   order by filetype_mcare, year(last_service_date);",
@@ -1281,7 +1281,7 @@ qa_stage.mcare_claim_procedure_qa_f <- function() {
     "select 'stg_claims.stage_mcare_claim_procedure' as 'table',
   'rows with non-null ICD procedure code 1' as qa_type,
   filetype_mcare, year(last_service_date) as service_year, count(*) as qa
-  from stg_claims.stage_mcare_claim_procedure_dev
+  from stg_claims.stage_mcare_claim_procedure
   where procedure_code is not null and 
     (len(procedure_code) = 7 or (len(procedure_code) <=4 and left(procedure_code, 1) like '[0-9]'))
   group by filetype_mcare, year(last_service_date)
@@ -1292,7 +1292,7 @@ qa_stage.mcare_claim_procedure_qa_f <- function() {
   res4 <- dbGetQuery(conn = inthealth, glue_sql(
     "select 'stg_claims.stage_mcare_claim_procedure' as 'table', '# members not in bene_enrollment, expect 0' as qa_type,
     count(a.id_mcare) as qa
-    from stg_claims.stage_mcare_claim_procedure_dev as a
+    from stg_claims.stage_mcare_claim_procedure as a
     left join stg_claims.mcare_bene_enrollment as b
     on a.id_mcare = b.bene_id
     where b.bene_id is null;",

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.yaml
@@ -1,5 +1,5 @@
 schema: stg_claims
-table: stage_mcare_claim_procedure
+table: stage_mcare_claim_procedure_dev
 vars:
     id_mcare: varchar(255) collate SQL_Latin1_General_Cp1_CS_AS
     claim_header_id: varchar(255) collate SQL_Latin1_General_Cp1_CS_AS

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.yaml
@@ -6,10 +6,6 @@ vars:
     first_service_date: date
     last_service_date: date
     procedure_code: varchar(255)
-    procedure_code_number: varchar(255)
-    modifier_1: varchar(255)
-    modifier_2: varchar(255)
-    modifier_3: varchar(255)
-    modifier_4: varchar(255)
+    modifier_code: varchar(255)
     filetype_mcare: varchar(255)
     last_run: datetime

--- a/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.yaml
+++ b/claims_db/phclaims/stage/tables/load_stage.mcare_claim_procedure.yaml
@@ -1,5 +1,5 @@
 schema: stg_claims
-table: stage_mcare_claim_procedure_dev
+table: stage_mcare_claim_procedure
 vars:
     id_mcare: varchar(255) collate SQL_Latin1_General_Cp1_CS_AS
     claim_header_id: varchar(255) collate SQL_Latin1_General_Cp1_CS_AS


### PR DESCRIPTION
Consolidating 4 modifier code columns into a single column will make querying simpler and more intuitive. Each row contains a distinct combination of person, claim_header_id, procedure code, and modifier code. If a given claim contains more than one distinct modifier code for a given procedure code, the procedure code will be repeated across multiple rows.

Removing procedure_code_number column as it is unnecessary per the following rationale:
- CPT are always 5-digit numeric codes

- HCPCS Level 1 are CPT codes, HCPCS Level 2 are 5-digit alphanumeric does (one letter followed by four numbers)
- BETOS codes are always alphanumeric and can be either 2 or 3 digits long (always starting with a letter)
- ICD-10-PCS codes are always 7 characters, strictly alphanumeric
- ICD-9-PCS codes are numeric and theoretically can be 5 digits and thus overlap with CPT codes, [however in looking](https://github.com/PHSKC-APDE/pers_eli/blob/main/qa_checks/mcare_icd9pcs_lengths.sql) at all relevant Medicare data (pre 10/1/2015), all ICD-9-PCS codes were either 3 digits or 4 digits
